### PR TITLE
feat(n8n): fix Telegram integration and live workflow setup

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -10,6 +10,8 @@ services:
       - N8N_BASIC_AUTH_PASSWORD=${N8N_PASSWORD}
       - GENERIC_TIMEZONE=Europe/Paris
       - TZ=Europe/Paris
+      - N8N_RESTRICT_FILE_ACCESS_TO=/data/rules
+      - TELEGRAM_CHAT_ID=${TELEGRAM_CHAT_ID}
     volumes:
       - n8n_data:/home/node/.n8n
       - ../rules:/data/rules:ro

--- a/rules/actions.json
+++ b/rules/actions.json
@@ -1,6 +1,6 @@
 {
   "$schema": "./actions.schema.json",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "default_action": "telegram",
   "rules": [
     {
@@ -15,8 +15,8 @@
         {
           "type": "telegram",
           "config": {
-            "chat_id": "{{ TELEGRAM_CHAT_ID }}",
-            "message_template": "🏆 *New AI/ML Competition*\n\n*Name:* {{competition_name}}\n*Deadline:* {{deadline}}\n*Prize:* {{prize}}\n*URL:* {{url}}"
+            "chat_id": "",
+            "message_template": "🏆 *New AI/ML Competition*\n\n*Name:* {competition_name}\n*Deadline:* {deadline}\n*Prize:* {prize}\n*URL:* {url}"
           }
         }
       ]
@@ -33,8 +33,8 @@
         {
           "type": "telegram",
           "config": {
-            "chat_id": "{{ TELEGRAM_CHAT_ID }}",
-            "message_template": "📊 *New Data Science Competition*\n\n*Name:* {{competition_name}}\n*Deadline:* {{deadline}}\n*Prize:* {{prize}}\n*URL:* {{url}}"
+            "chat_id": "",
+            "message_template": "📊 *New Data Science Competition*\n\n*Name:* {competition_name}\n*Deadline:* {deadline}\n*Prize:* {prize}\n*URL:* {url}"
           }
         }
       ]
@@ -51,8 +51,8 @@
         {
           "type": "telegram",
           "config": {
-            "chat_id": "{{ TELEGRAM_CHAT_ID }}",
-            "message_template": "🔔 *New Kaggle Competition*\n\n*Name:* {{competition_name}}\n*Deadline:* {{deadline}}\n*Prize:* {{prize}}\n*URL:* {{url}}"
+            "chat_id": "",
+            "message_template": "🔔 *New Kaggle Competition*\n\n*Name:* {competition_name}\n*Deadline:* {deadline}\n*Prize:* {prize}\n*URL:* {url}"
           }
         }
       ]
@@ -69,8 +69,8 @@
         {
           "type": "telegram",
           "config": {
-            "chat_id": "{{ TELEGRAM_CHAT_ID }}",
-            "message_template": "⚡ *New AI/ML Hackathon*\n\n*Name:* {{competition_name}}\n*Deadline:* {{deadline}}\n*Prize:* {{prize}}\n*URL:* {{url}}\n\n_Hackathons are typically shorter with faster deadlines._"
+            "chat_id": "",
+            "message_template": "⚡ *New AI/ML Hackathon*\n\n*Name:* {competition_name}\n*Deadline:* {deadline}\n*Prize:* {prize}\n*URL:* {url}\n\n_Hackathons are typically shorter with faster deadlines._"
           }
         }
       ]
@@ -87,8 +87,8 @@
         {
           "type": "telegram",
           "config": {
-            "chat_id": "{{ TELEGRAM_CHAT_ID }}",
-            "message_template": "⚡ *New Kaggle Hackathon*\n\n*Name:* {{competition_name}}\n*Deadline:* {{deadline}}\n*Prize:* {{prize}}\n*URL:* {{url}}\n\n_Hackathons are typically shorter with faster deadlines._"
+            "chat_id": "",
+            "message_template": "⚡ *New Kaggle Hackathon*\n\n*Name:* {competition_name}\n*Deadline:* {deadline}\n*Prize:* {prize}\n*URL:* {url}\n\n_Hackathons are typically shorter with faster deadlines._"
           }
         }
       ]

--- a/workflows/kaggle-email-watcher.json
+++ b/workflows/kaggle-email-watcher.json
@@ -6,29 +6,26 @@
         "pollTimes": {
           "item": [
             {
-              "mode": "everyDay",
-              "hour": 8,
-              "minute": 0
+              "hour": 8
             }
           ]
         },
         "filters": {
-          "sender": "no-reply@kaggle.com",
-          "subject": "Launch"
-        },
-        "options": {
-          "downloadAttachments": false
+          "sender": "no-reply@kaggle.com"
         }
       },
-      "id": "gmail-trigger",
+      "id": "08e88448-1c0a-448e-9d5f-649da6f12ede",
       "name": "Gmail Trigger",
       "type": "n8n-nodes-base.gmailTrigger",
       "typeVersion": 1,
-      "position": [250, 300],
+      "position": [
+        -1328,
+        112
+      ],
       "credentials": {
         "gmailOAuth2": {
-          "id": "GMAIL_CREDENTIAL_ID",
-          "name": "Gmail OAuth2"
+          "id": "H7OQ6QxEqOZPzBKm",
+          "name": "Gmail account"
         }
       }
     },
@@ -37,49 +34,61 @@
         "conditions": {
           "string": [
             {
-              "value1": "={{ $json.from.value[0].address }}",
+              "value1": "={{ $json.From }}",
               "operation": "contains",
               "value2": "kaggle.com"
             }
           ]
         }
       },
-      "id": "filter-kaggle",
+      "id": "4091de45-3302-4ade-947d-6f2de57477e6",
       "name": "Filter Kaggle Sender",
       "type": "n8n-nodes-base.filter",
       "typeVersion": 1,
-      "position": [470, 300]
+      "position": [
+        -1104,
+        112
+      ]
     },
     {
       "parameters": {
         "jsCode": "// Parse Kaggle Competition/Hackathon Launch email\n// Verified against real emails:\n//   Competition: \"Competition Launch: ARC Prize 2026\" — uses \"Entry Deadline:\"\n//   Hackathon:   \"Hackathon Launch: The MedGemma Impact Challenge\" — uses \"Final Submission:\"\nconst subject = $input.first().json.subject || '';\nconst body = $input.first().json.text || '';\nconst html = $input.first().json.html || '';\n\n// Detect event type from subject\nlet eventType = 'competition';\nif (subject.match(/Hackathon Launch/i)) {\n  eventType = 'hackathon';\n}\n\n// Extract name from subject — format: \"Competition Launch: ARC Prize 2026\"\n// Note: name can contain colons (e.g. \"Measuring Progress Toward AGI: Cognitive Abilities\")\nconst nameMatch = subject.match(/(?:Competition|Hackathon)\\s+Launch:\\s*(.+)/i);\nconst competitionName = nameMatch ? nameMatch[1].trim() : subject;\n\n// Strip HTML tags for text search\nconst searchText = body || html.replace(/<[^>]+>/g, ' ').replace(/\\s+/g, ' ');\n\n// Extract deadline\n// Competition emails use \"Entry Deadline:\", Hackathon emails use \"Final Submission:\"\nconst deadlinePatterns = [\n  /Entry Deadline[:\\s]*([A-Za-z]+\\s+\\d{1,2},?\\s+\\d{4})/i,\n  /Final Submission[:\\s]*([A-Za-z]+\\s+\\d{1,2},?\\s+\\d{4})/i,\n  /Submission Deadline[:\\s]*([A-Za-z]+\\s+\\d{1,2},?\\s+\\d{4})/i,\n  /deadline[:\\s]+([A-Za-z]+\\s+\\d{1,2},?\\s+\\d{4})/i,\n  /ends?\\s+on\\s+([A-Za-z]+\\s+\\d{1,2},?\\s+\\d{4})/i\n];\nlet deadline = 'Unknown';\nfor (const pattern of deadlinePatterns) {\n  const match = searchText.match(pattern);\n  if (match) {\n    deadline = match[1].trim();\n    break;\n  }\n}\n\n// Extract prize — format: \"Total Prizes:\" then \"$2,000,000\" or \"$100,000\"\nconst prizeMatch = searchText.match(/Total Prizes?[:\\s]*(\\$[\\d,\\.]+)/i);\nconst prize = prizeMatch ? prizeMatch[1].trim() : 'Not specified';\n\n// Extract Kaggle URL from HTML (links in <a href=\"...\">)\nconst urlPatterns = [\n  /https:\\/\\/www\\.kaggle\\.com\\/competitions\\/[^\\s\\\"'<>]+/i,\n  /https:\\/\\/www\\.kaggle\\.com\\/c\\/[^\\s\\\"'<>]+/i\n];\nlet url = 'https://www.kaggle.com/competitions';\nfor (const pattern of urlPatterns) {\n  const match = html.match(pattern) || body.match(pattern);\n  if (match) {\n    url = match[0];\n    break;\n  }\n}\n\n// Infer track from email content (Kaggle emails have no explicit track field)\n// Keywords are matched against subject + body to classify the competition\nconst content = (subject + ' ' + searchText).toLowerCase();\nconst trackKeywords = [\n  { track: 'AI/ML', keywords: ['machine learning', 'deep learning', 'neural network', 'ai model', 'llm', 'nlp', 'computer vision', 'reinforcement learning', 'agi', 'generalization', 'reasoning'] },\n  { track: 'Data Science', keywords: ['data science', 'tabular', 'regression', 'classification', 'analytics', 'feature engineering', 'eda'] },\n  { track: 'Healthcare', keywords: ['medical', 'health', 'clinical', 'patient', 'diagnostics', 'biomedical', 'medgemma'] },\n  { track: 'Environment', keywords: ['climate', 'wildlife', 'biodiversity', 'species', 'bird', 'ecology', 'environmental'] }\n];\nlet track = 'Other';\nfor (const entry of trackKeywords) {\n  if (entry.keywords.some(kw => content.includes(kw))) {\n    track = entry.track;\n    break;\n  }\n}\n\nreturn [{\n  json: {\n    event_type: eventType,\n    competition_name: competitionName,\n    deadline: deadline,\n    prize: prize,\n    track: track,\n    url: url,\n    raw_subject: subject\n  }\n}];"
       },
-      "id": "parse-email",
+      "id": "a14bb4a1-7bf4-4c8f-b448-67216e0c83a9",
       "name": "Parse Email",
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
-      "position": [690, 300]
+      "position": [
+        -880,
+        112
+      ]
     },
     {
       "parameters": {
-        "filePath": "/data/rules/actions.json",
+        "fileSelector": "/data/rules/actions.json",
         "options": {}
       },
-      "id": "read-rules",
+      "id": "dc0aedb5-c041-44cd-b15a-fc83a569f9dc",
       "name": "Read Rules",
       "type": "n8n-nodes-base.readWriteFile",
       "typeVersion": 1,
-      "position": [910, 300]
+      "position": [
+        -656,
+        112
+      ]
     },
     {
       "parameters": {
-        "jsCode": "// Match parsed email data against rules (supports event_type: competition/hackathon)\nconst emailData = $('Parse Email').first().json;\nconst rulesFile = JSON.parse($input.first().json.data);\nconst rules = rulesFile.rules;\n\nlet matchedRule = null;\n\nfor (const rule of rules) {\n  // Check event_type match first\n  const ruleEventType = rule.match.event_type || '*';\n  if (ruleEventType !== '*' && ruleEventType !== emailData.event_type) {\n    continue;\n  }\n  \n  const tracks = rule.match.track;\n  \n  // Check track match\n  let trackMatch = false;\n  if (tracks.includes('*')) {\n    trackMatch = true;\n  } else {\n    const emailTrack = emailData.track.toLowerCase();\n    trackMatch = tracks.some(t => emailTrack.includes(t.toLowerCase()));\n  }\n  \n  if (!trackMatch) continue;\n  \n  // Check keyword match in competition name\n  let keywordMatch = true;\n  if (rule.match.keyword_in_name && rule.match.keyword_in_name.length > 0) {\n    const name = emailData.competition_name.toLowerCase();\n    keywordMatch = rule.match.keyword_in_name.some(k => name.includes(k.toLowerCase()));\n  }\n  \n  if (keywordMatch) {\n    matchedRule = rule;\n    break;\n  }\n}\n\nif (!matchedRule) {\n  matchedRule = {\n    id: 'default',\n    name: 'Default Action',\n    actions: [{ type: rulesFile.default_action, config: {} }]\n  };\n}\n\n// Merge email data with matched rule actions\nconst results = matchedRule.actions.map(action => ({\n  json: {\n    ...emailData,\n    action_type: action.type,\n    action_config: action.config,\n    matched_rule: matchedRule.name\n  }\n}));\n\nreturn results;"
+        "jsCode": "// Match parsed email data against rules (supports event_type: competition/hackathon)\nconst emailData = $('Parse Email').first().json;\nconst binaryData = await this.helpers.getBinaryDataBuffer(0, 'data');\nconst rulesFile = JSON.parse(binaryData.toString());\nconst rules = rulesFile.rules;\n\nlet matchedRule = null;\n\nfor (const rule of rules) {\n  // Check event_type match first\n  const ruleEventType = rule.match.event_type || '*';\n  if (ruleEventType !== '*' && ruleEventType !== emailData.event_type) {\n    continue;\n  }\n  \n  const tracks = rule.match.track;\n  \n  // Check track match\n  let trackMatch = false;\n  if (tracks.includes('*')) {\n    trackMatch = true;\n  } else {\n    const emailTrack = emailData.track.toLowerCase();\n    trackMatch = tracks.some(t => emailTrack.includes(t.toLowerCase()));\n  }\n  \n  if (!trackMatch) continue;\n  \n  // Check keyword match in competition name\n  let keywordMatch = true;\n  if (rule.match.keyword_in_name && rule.match.keyword_in_name.length > 0) {\n    const name = emailData.competition_name.toLowerCase();\n    keywordMatch = rule.match.keyword_in_name.some(k => name.includes(k.toLowerCase()));\n  }\n  \n  if (keywordMatch) {\n    matchedRule = rule;\n    break;\n  }\n}\n\nif (!matchedRule) {\n  matchedRule = {\n    id: 'default',\n    name: 'Default Action',\n    actions: [{ type: rulesFile.default_action, config: {} }]\n  };\n}\n\n// Merge email data with matched rule actions\nconst results = matchedRule.actions.map(action => {\n  const config = { ...action.config };\n  if (!config.chat_id) {\n    config.chat_id = '899627563';\n  }\n  return {\n    json: {\n      ...emailData,\n      action_type: action.type,\n      action_config: config,\n      matched_rule: matchedRule.name\n    }\n  };\n});\n\nreturn results;\n"
       },
-      "id": "match-rule",
+      "id": "b5324da3-b167-46e1-8ef3-8112196c6dc7",
       "name": "Match Rule",
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
-      "position": [1130, 300]
+      "position": [
+        -448,
+        112
+      ]
     },
     {
       "parameters": {
@@ -93,8 +102,7 @@
                     "value2": "telegram"
                   }
                 ]
-              },
-              "outputKey": "telegram"
+              }
             },
             {
               "conditions": {
@@ -104,8 +112,7 @@
                     "value2": "discord"
                   }
                 ]
-              },
-              "outputKey": "discord"
+              }
             },
             {
               "conditions": {
@@ -115,8 +122,7 @@
                     "value2": "notion"
                   }
                 ]
-              },
-              "outputKey": "notion"
+              }
             },
             {
               "conditions": {
@@ -126,36 +132,42 @@
                     "value2": "google_sheet"
                   }
                 ]
-              },
-              "outputKey": "google_sheet"
+              }
             }
           ]
         },
-        "fallbackOutput": "extra"
+        "options": {}
       },
-      "id": "switch-action",
+      "id": "3439e081-45ee-46bc-8f10-fffac49da17f",
       "name": "Route by Action Type",
       "type": "n8n-nodes-base.switch",
       "typeVersion": 3,
-      "position": [1350, 300]
+      "position": [
+        -224,
+        112
+      ]
     },
     {
       "parameters": {
-        "chatId": "={{ $json.action_config.chat_id || '' }}",
-        "text": "={{ $json.action_config.message_template ? $json.action_config.message_template.replace('{{competition_name}}', $json.competition_name).replace('{{track}}', $json.track).replace('{{deadline}}', $json.deadline).replace('{{url}}', $json.url).replace('{{event_type}}', $json.event_type).replace('{{prize}}', $json.prize) : '🔔 New ' + $json.event_type + ': ' + $json.competition_name }}",
+        "chatId": "899627563",
+        "text": "=={{ $json.action_config.message_template ? $json.action_config.message_template.replace('{competition_name}', $json.competition_name).replace('{track}', $json.track).replace('{deadline}', $json.deadline).replace('{url}', $json.url).replace('{event_type}', $json.event_type).replace('{prize}', $json.prize) : '🔔 New ' + $json.event_type + ': ' + $json.competition_name }}",
         "additionalFields": {
           "parse_mode": "Markdown"
         }
       },
-      "id": "telegram-send",
+      "id": "d6001c2e-3e3c-4bf4-93c1-a91d10e5a569",
       "name": "Send Telegram",
       "type": "n8n-nodes-base.telegram",
       "typeVersion": 1.2,
-      "position": [1570, 200],
+      "position": [
+        0,
+        0
+      ],
+      "webhookId": "5f930ddb-cc74-4bdd-8fa3-16903d840890",
       "credentials": {
         "telegramApi": {
-          "id": "TELEGRAM_CREDENTIAL_ID",
-          "name": "Telegram Bot"
+          "id": "MoBZkdwcMf6InLvh",
+          "name": "Telegram account"
         }
       }
     },
@@ -163,13 +175,17 @@
       "parameters": {
         "jsCode": "// Log action for unhandled types\nconsole.log('Unhandled action type:', $json.action_type);\nconsole.log('Competition:', $json.competition_name);\nconsole.log('Matched rule:', $json.matched_rule);\nreturn [$input.first()];"
       },
-      "id": "log-fallback",
+      "id": "39549557-a44c-40bb-a991-fbfdd5a9a4ad",
       "name": "Log (Fallback)",
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
-      "position": [1570, 500]
+      "position": [
+        0,
+        304
+      ]
     }
   ],
+  "pinData": {},
   "connections": {
     "Gmail Trigger": {
       "main": [
@@ -255,26 +271,32 @@
             "type": "main",
             "index": 0
           }
-        ],
-        [
-          {
-            "node": "Log (Fallback)",
-            "type": "main",
-            "index": 0
-          }
         ]
       ]
     }
   },
+  "active": false,
   "settings": {
-    "executionOrder": "v1"
+    "executionOrder": "v1",
+    "binaryMode": "separate"
   },
-  "staticData": null,
+  "versionId": "8a055c40-bcd9-48b9-8734-4e8c6c0a47b2",
+  "meta": {
+    "templateCredsSetupCompleted": true,
+    "instanceId": "f9bfe6cd1c79dd7cb9de6726ece7dec9954ca6bb6d178ebc8bb99344cc2fe7b3"
+  },
+  "id": "EPPiL2xGkRQUtGGO",
   "tags": [
     {
+      "updatedAt": "2026-03-31T13:53:18.718Z",
+      "createdAt": "2026-03-31T13:53:18.718Z",
+      "id": "WusF1fudmUgScw5G",
       "name": "kaggle"
     },
     {
+      "updatedAt": "2026-03-31T13:53:18.720Z",
+      "createdAt": "2026-03-31T13:53:18.720Z",
+      "id": "f11ZSGB6947pcHgX",
       "name": "automation"
     }
   ]


### PR DESCRIPTION
## Summary

- Fix Telegram node Chat ID resolution: use fixed value instead of broken `{{ TELEGRAM_CHAT_ID }}` env var syntax
- Fix template syntax error: switch from `{{var}}` to `{var}` delimiters in `actions.json` to avoid n8n expression parser conflict
- Add `TELEGRAM_CHAT_ID` env var and `N8N_RESTRICT_FILE_ACCESS_TO` to docker-compose
- Export live workflow from n8n UI with real credentials and tested Telegram integration
- Bump rules version to 1.3.0

## Checklist

- [x] Telegram notification received successfully on test execution
- [x] `make validate` passes (JSON + schema validation)
- [x] No secrets committed (credentials are in `.env` which is gitignored)
- [x] Chat ID hardcoded in Match Rule code node as fallback for empty `actions.json` values

Closes #