### PR TITLE
feat(n8n): add daily heartbeat workflow with Telegram notification

### DIFF
--- a/PROJECT_LOG.md
+++ b/PROJECT_LOG.md
@@ -58,3 +58,11 @@ This is the operational logbook, not a release changelog.
 - **PROJECT_LOG.md** created — chronological operational logbook (agent-agnostic, DIP-compliant)
 - Principle added to global CLAUDE.md: every project must maintain a `PROJECT_LOG.md`
 - Decision: this is NOT a release changelog — it is the day-to-day operational journal
+
+### Heartbeat workflow
+
+- **Issue #9** created — daily heartbeat Telegram notification
+- Heartbeat workflow built in n8n UI: Schedule Trigger (07:55 daily) → Send Telegram ("n8n is alive")
+- Workflow published and active in n8n
+- Exported to `workflows/heartbeat.json`
+- PR review comment procedure updated in global CLAUDE.md: added "Disagree" priority, duplicate grouping, re-fetch cycle, and "do NOT resolve conversations" rule

--- a/workflows/heartbeat.json
+++ b/workflows/heartbeat.json
@@ -1,0 +1,75 @@
+{
+  "name": "Heartbeat",
+  "nodes": [
+    {
+      "parameters": {
+        "rule": {
+          "interval": [
+            {
+              "triggerAtHour": 7,
+              "triggerAtMinute": 55
+            }
+          ]
+        }
+      },
+      "type": "n8n-nodes-base.scheduleTrigger",
+      "typeVersion": 1.3,
+      "position": [
+        0,
+        0
+      ],
+      "id": "57a2ef8f-7563-4f86-b4e6-030acc1426ff",
+      "name": "Schedule Trigger"
+    },
+    {
+      "parameters": {
+        "chatId": "899627563",
+        "text": "✅ n8n is alive — Kaggle watcher active, next poll at 08:00",
+        "additionalFields": {
+          "parse_mode": "Markdown"
+        }
+      },
+      "type": "n8n-nodes-base.telegram",
+      "typeVersion": 1.2,
+      "position": [
+        208,
+        0
+      ],
+      "id": "15036d1a-df15-4618-8ca8-08c82717e0d0",
+      "name": "Send a text message",
+      "webhookId": "baac3b5b-8d4b-4262-9260-0c3e73fb6040",
+      "credentials": {
+        "telegramApi": {
+          "id": "MoBZkdwcMf6InLvh",
+          "name": "Telegram account"
+        }
+      }
+    }
+  ],
+  "pinData": {},
+  "connections": {
+    "Schedule Trigger": {
+      "main": [
+        [
+          {
+            "node": "Send a text message",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "active": true,
+  "settings": {
+    "executionOrder": "v1",
+    "binaryMode": "separate"
+  },
+  "versionId": "2c1228a8-da37-414d-9ad3-9bb2d63cca6f",
+  "meta": {
+    "templateCredsSetupCompleted": true,
+    "instanceId": "f9bfe6cd1c79dd7cb9de6726ece7dec9954ca6bb6d178ebc8bb99344cc2fe7b3"
+  },
+  "id": "UHkR4VXAwawL3avY",
+  "tags": []
+}


### PR DESCRIPTION
## Summary

- Add a lightweight heartbeat workflow: Schedule Trigger at 07:55 Europe/Paris sends a Telegram health check message confirming n8n is alive before the 08:00 Gmail poll
- Exported from live n8n instance, workflow published and active
- Update PROJECT_LOG.md with heartbeat and governance entries

## Checklist

- [x] Telegram notification received on test execution
- [x] Workflow published and active in n8n
- [x] `heartbeat.json` is valid JSON
- [x] `make validate` passes (existing validations unaffected)
- [x] No impact on Kaggle Email Watcher workflow

Closes #9