### PR TITLE
fix(n8n): address PR #10 Copilot review comments

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,7 @@ All code, comments, commits, and documentation in English.
 ## Key Files
 
 - `workflows/kaggle-email-watcher.json` — n8n workflow (edit in n8n UI, export as JSON)
+- `workflows/heartbeat.json` — daily health check workflow (07:55 Telegram notification)
 - `rules/actions.json` — rules engine configuration (validated by `rules/actions.schema.json`)
 - `docker/docker-compose.yml` — self-hosted n8n deployment
 - `Makefile` — project commands (`make up`, `make down`, `make validate`, `make logs`)
@@ -31,7 +32,7 @@ Run `make validate` before committing changes to `rules/` or `workflows/`.
 ## PR Review Comments
 
 Follow the global PR review comment procedure (see `~/.claude/CLAUDE.md`).
-Summary: fetch → evaluate priority → reply inline → implement must-haves → verify CI → resolve thread.
+Summary: fetch → evaluate priority → group duplicates → reply inline per comment → implement must-haves → re-fetch after push → verify CI. Do NOT resolve conversations — leave that to the human PR author.
 
 ## Do Not
 

--- a/PROJECT_LOG.md
+++ b/PROJECT_LOG.md
@@ -65,4 +65,4 @@ This is the operational logbook, not a release changelog.
 - Heartbeat workflow built in n8n UI: Schedule Trigger (07:55 daily) → Send Telegram ("n8n is alive")
 - Workflow published and active in n8n
 - Exported to `workflows/heartbeat.json`
-- PR review comment procedure updated in global CLAUDE.md: added "Disagree" priority, duplicate grouping, re-fetch cycle, and "do NOT resolve conversations" rule
+- PR review comment procedure updated in global CLAUDE.md: added "Disagree" priority, duplicate grouping, re-fetch cycle, and "do NOT resolve conversations" rule; this repository's CLAUDE.md summary updated to match

--- a/workflows/heartbeat.json
+++ b/workflows/heartbeat.json
@@ -60,7 +60,7 @@
       ]
     }
   },
-  "active": true,
+  "active": false,
   "settings": {
     "executionOrder": "v1",
     "binaryMode": "separate"


### PR DESCRIPTION
## Summary

- Set `heartbeat.json` active flag to `false` for safe import (matches `kaggle-email-watcher.json` convention)
- Update repo CLAUDE.md review procedure summary: remove "resolve thread", add "do NOT resolve conversations"
- Add `heartbeat.json` to key files in CLAUDE.md

These fixes address Copilot review comments from PR #10 that were merged before comments were processed.

## Checklist

- [x] `heartbeat.json` active flag set to `false`
- [x] CLAUDE.md review procedure wording aligned with global convention
- [x] `make validate` passes