### PR TITLE
docs(social): add social preview image template

### DIFF
--- a/docs/social-preview.html
+++ b/docs/social-preview.html
@@ -1,0 +1,139 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Social Preview — n8n-kaggle-watcher</title>
+<style>
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body {
+    width: 1280px;
+    height: 640px;
+    background: linear-gradient(135deg, #0d1117 0%, #161b22 50%, #1a1e2e 100%);
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif;
+    color: #e6edf3;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    overflow: hidden;
+    position: relative;
+  }
+
+  .bg-grid {
+    position: absolute;
+    top: 0; left: 0; right: 0; bottom: 0;
+    background-image:
+      linear-gradient(rgba(255,255,255,0.03) 1px, transparent 1px),
+      linear-gradient(90deg, rgba(255,255,255,0.03) 1px, transparent 1px);
+    background-size: 40px 40px;
+  }
+
+  .content {
+    position: relative;
+    z-index: 1;
+    text-align: center;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 28px;
+  }
+
+  .title {
+    font-size: 64px;
+    font-weight: 700;
+    letter-spacing: -1px;
+    background: linear-gradient(90deg, #58a6ff, #79c0ff);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+  }
+
+  .tagline {
+    font-size: 24px;
+    color: #8b949e;
+    max-width: 800px;
+    line-height: 1.4;
+  }
+
+  .flow {
+    display: flex;
+    align-items: center;
+    gap: 16px;
+    margin-top: 12px;
+  }
+
+  .node {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    background: rgba(255,255,255,0.06);
+    border: 1px solid rgba(255,255,255,0.1);
+    border-radius: 12px;
+    padding: 14px 22px;
+    font-size: 18px;
+    font-weight: 500;
+  }
+
+  .node .icon {
+    font-size: 28px;
+  }
+
+  .arrow {
+    font-size: 24px;
+    color: #58a6ff;
+    font-weight: 300;
+  }
+
+  .badges {
+    display: flex;
+    gap: 12px;
+    margin-top: 8px;
+  }
+
+  .badge {
+    font-size: 13px;
+    padding: 5px 14px;
+    border-radius: 20px;
+    font-weight: 500;
+  }
+
+  .badge-n8n {
+    background: rgba(255, 107, 53, 0.15);
+    color: #ff6b35;
+    border: 1px solid rgba(255, 107, 53, 0.3);
+  }
+
+  .badge-docker {
+    background: rgba(0, 136, 255, 0.15);
+    color: #0088ff;
+    border: 1px solid rgba(0, 136, 255, 0.3);
+  }
+
+  .badge-mit {
+    background: rgba(63, 185, 80, 0.15);
+    color: #3fb950;
+    border: 1px solid rgba(63, 185, 80, 0.3);
+  }
+</style>
+</head>
+<body>
+  <div class="bg-grid"></div>
+  <div class="content">
+    <div class="title">n8n-kaggle-watcher</div>
+    <div class="tagline">Automated Kaggle competition & hackathon alerts via Gmail, n8n, and Telegram</div>
+    <div class="flow">
+      <div class="node"><span class="icon">📧</span> Gmail</div>
+      <div class="arrow">→</div>
+      <div class="node"><span class="icon">⚙️</span> n8n</div>
+      <div class="arrow">→</div>
+      <div class="node"><span class="icon">📋</span> Rules</div>
+      <div class="arrow">→</div>
+      <div class="node"><span class="icon">📱</span> Telegram</div>
+    </div>
+    <div class="badges">
+      <span class="badge badge-n8n">n8n self-hosted</span>
+      <span class="badge badge-docker">Docker</span>
+      <span class="badge badge-mit">MIT License</span>
+    </div>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- Add HTML template (`docs/social-preview.html`) for generating the GitHub Open Graph social preview image
- Dark theme, 1280x640, with project title, tagline, flow diagram (Gmail → n8n → Rules → Telegram), and tech badges
- Social preview image uploaded to repo settings

## Checklist

- [x] HTML template renders correctly at 1280x640
- [x] Social preview uploaded in GitHub Settings → Social preview
- [x] Template committed for future updates

Closes #4