### PR TITLE
feat(ci): add lint checks for YAML, shell, and markdown

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,11 +1,8 @@
-name: Validate JSON
+name: Validate & Lint
 
 on:
   pull_request:
     branches: [main]
-    paths:
-      - "rules/**"
-      - "workflows/**"
 
 jobs:
   validate:
@@ -27,5 +24,28 @@ jobs:
           print('actions.json is valid')
           "
 
-      - name: Validate n8n workflow JSON syntax
-        run: python3 -c "import json; json.load(open('workflows/kaggle-email-watcher.json')); print('workflow JSON is valid')"
+      - name: Validate all workflow JSON syntax
+        run: |
+          for wf in workflows/*.json; do
+            python3 -c "import json; json.load(open('$wf')); print('$wf is valid')"
+          done
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: YAML lint
+        run: |
+          pip install yamllint
+          yamllint -d relaxed docker/docker-compose.yml
+
+      - name: Shell lint
+        run: shellcheck scripts/*.sh
+
+      - name: Markdown lint
+        uses: DavidAnson/markdownlint-cli2-action@v19
+        with:
+          globs: "*.md"
+          config: ".markdownlint.json"

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,7 @@
+{
+  "MD013": false,
+  "MD033": false,
+  "MD040": false,
+  "MD041": false,
+  "MD060": false
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,6 +24,7 @@ Always branch from `main`. Never commit directly to `main`.
 **Scopes:** `n8n`, `rules`, `docker`, `ci`, `docs`
 
 **Examples:**
+
 ```
 feat(n8n): add Telegram notification node
 fix(rules): correct track matching logic

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: up down logs validate help
+.PHONY: up down logs validate lint check help
 
 COMPOSE := docker compose -f docker/docker-compose.yml --env-file docker/.env
 
@@ -17,3 +17,8 @@ logs: ## Show n8n logs (follow mode)
 
 validate: ## Validate JSON files (rules + workflow)
 	@bash scripts/validate-rules.sh
+
+lint: ## Run linters (yaml, shell, markdown)
+	@bash scripts/lint.sh
+
+check: validate lint ## Run all checks (validate + lint)

--- a/PROJECT_LOG.md
+++ b/PROJECT_LOG.md
@@ -84,3 +84,9 @@ This is the operational logbook, not a release changelog.
 - **PR #13** merged — social preview HTML template (`docs/social-preview.html`), dark theme 1280x640, uploaded to GitHub Settings
 - **PR #14** merged — fix PR #13 Copilot review comments (HTML entity escape, emoji fonts, capture procedure documentation)
 - **Issue #4** closed
+
+### CI lint checks (in progress)
+
+- Branch `feat/ci-lint-checks` created — adding yamllint, shellcheck, markdownlint to CI
+- Tools installed locally: yamllint (pipx), shellcheck (binary), markdownlint-cli2 (npx)
+- Remaining: update validate script, add `make lint`, update CI workflow

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+
+ERRORS=0
+
+echo "=== YAML lint ==="
+if command -v yamllint &>/dev/null; then
+  if yamllint -d relaxed "$PROJECT_ROOT/docker/docker-compose.yml"; then
+    echo "✓ docker-compose.yml passes yamllint"
+  else
+    echo "✗ docker-compose.yml has yamllint errors"
+    ERRORS=$((ERRORS + 1))
+  fi
+else
+  echo "⚠ yamllint not installed (pipx install yamllint)"
+fi
+
+echo ""
+echo "=== Shell lint ==="
+if command -v shellcheck &>/dev/null; then
+  for script in "$PROJECT_ROOT"/scripts/*.sh; do
+    name=$(basename "$script")
+    if shellcheck "$script"; then
+      echo "✓ $name passes shellcheck"
+    else
+      echo "✗ $name has shellcheck errors"
+      ERRORS=$((ERRORS + 1))
+    fi
+  done
+else
+  echo "⚠ shellcheck not installed"
+fi
+
+echo ""
+echo "=== Markdown lint ==="
+if command -v npx &>/dev/null; then
+  cd "$PROJECT_ROOT"
+  if npx --yes markdownlint-cli2 --config .markdownlint.json README.md CONTRIBUTING.md PROJECT_LOG.md 2>&1; then
+    echo "✓ Markdown files pass lint"
+  else
+    echo "⚠ Markdown lint warnings (non-blocking)"
+  fi
+else
+  echo "⚠ npx not available — skipping markdown lint"
+fi
+
+echo ""
+if [ "$ERRORS" -gt 0 ]; then
+  echo "=== $ERRORS lint error(s) found ==="
+  exit 1
+else
+  echo "=== All lint checks passed ==="
+fi

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -15,7 +15,8 @@ if command -v yamllint &>/dev/null; then
     ERRORS=$((ERRORS + 1))
   fi
 else
-  echo "⚠ yamllint not installed (pipx install yamllint)"
+  echo "✗ yamllint not installed (pipx install yamllint)"
+  ERRORS=$((ERRORS + 1))
 fi
 
 echo ""
@@ -31,7 +32,8 @@ if command -v shellcheck &>/dev/null; then
     fi
   done
 else
-  echo "⚠ shellcheck not installed"
+  echo "✗ shellcheck not installed"
+  ERRORS=$((ERRORS + 1))
 fi
 
 echo ""
@@ -41,10 +43,12 @@ if command -v npx &>/dev/null; then
   if npx --yes markdownlint-cli2 --config .markdownlint.json README.md CONTRIBUTING.md PROJECT_LOG.md 2>&1; then
     echo "✓ Markdown files pass lint"
   else
-    echo "⚠ Markdown lint warnings (non-blocking)"
+    echo "✗ Markdown files have lint errors"
+    ERRORS=$((ERRORS + 1))
   fi
 else
-  echo "⚠ npx not available — skipping markdown lint"
+  echo "✗ npx not available — cannot run markdown lint"
+  ERRORS=$((ERRORS + 1))
 fi
 
 echo ""

--- a/scripts/validate-rules.sh
+++ b/scripts/validate-rules.sh
@@ -14,13 +14,16 @@ else
   exit 1
 fi
 
-# Check workflow JSON syntax
-if python3 -c "import json; json.load(open('$PROJECT_ROOT/workflows/kaggle-email-watcher.json'))"; then
-  echo "✓ kaggle-email-watcher.json is valid JSON"
-else
-  echo "✗ kaggle-email-watcher.json has invalid JSON syntax"
-  exit 1
-fi
+# Check all workflow JSON syntax
+for wf in "$PROJECT_ROOT"/workflows/*.json; do
+  name=$(basename "$wf")
+  if python3 -c "import json; json.load(open('$wf'))"; then
+    echo "✓ $name is valid JSON"
+  else
+    echo "✗ $name has invalid JSON syntax"
+    exit 1
+  fi
+done
 
 # Validate against schema (if jsonschema is available)
 if python3 -c "


### PR DESCRIPTION
## Summary

- Extend `validate-rules.sh` to validate all `workflows/*.json` (including `heartbeat.json`)
- Add `scripts/lint.sh` with three linters: yamllint, shellcheck, markdownlint-cli2
- Add `make lint` and `make check` (validate + lint) targets to Makefile
- Update CI workflow with a new `lint` job running YAML, shell, and markdown checks
- Add `.markdownlint.json` config (disable MD013, MD033, MD040, MD041, MD060)
- Fix CONTRIBUTING.md blank line before fenced code block (MD031)

## New commands

```bash
make validate   # JSON validation only (existing)
make lint       # YAML + shell + markdown linting (new)
make check      # All checks: validate + lint (new)
```

## Checklist

- [x] `make check` passes locally (all green)
- [x] yamllint validates docker-compose.yml
- [x] shellcheck passes on all scripts/*.sh
- [x] markdownlint passes on README.md, CONTRIBUTING.md, PROJECT_LOG.md
- [x] CI workflow updated with lint job