### PR TITLE
fix(docker): switch to host network mode and remove deprecated auth env vars

### DIFF
--- a/PROJECT_LOG.md
+++ b/PROJECT_LOG.md
@@ -174,3 +174,14 @@ All v1.0 issues closed (10/10). Repo public, workflows operational, post LinkedI
 - **Issue #27** — Inline keyboard buttons in Telegram notifications (blocked by infra)
 - **Issue #28** — Automated Kaggle repo creation from Telegram (depends on #27)
 - **Issue #29** — AI-powered competition analysis and backlog generation (depends on #28)
+
+## 2026-04-12
+
+### Fix — Docker network incident
+
+- Incident: n8n editor unreachable from host (HTTP 000), Gmail Trigger failing with `'undefined'` error, outbound connectivity broken from container (100% packet loss on custom bridge network).
+- Root cause: `iptables-nft` conflict with Docker — `DOCKER-ISOLATION-STAGE-2` chain missing, preventing any custom bridge network from being created. Neither Docker daemon restart nor manual chain creation resolved it.
+- Fix: switched `docker-compose.yml` to `network_mode: host` — bypasses Docker bridge networking entirely, appropriate for this single-container deployment. n8n now binds directly to host port 5678.
+- Also removed deprecated `N8N_BASIC_AUTH_*` environment variables (removed in n8n v1.0, silently ignored by v2.14.2). Auth is now managed via n8n built-in user management.
+- Verified: container up, outbound connectivity OK, editor returns HTTP 200, Heartbeat workflow active and firing.
+- Remaining: Gmail OAuth refresh token is expired/revoked (independent of network incident) — requires re-authentication via Google Cloud Console.

--- a/PROJECT_LOG.md
+++ b/PROJECT_LOG.md
@@ -182,6 +182,7 @@ All v1.0 issues closed (10/10). Repo public, workflows operational, post LinkedI
 - Incident: n8n editor unreachable from host (HTTP 000), Gmail Trigger failing with `'undefined'` error, outbound connectivity broken from container (100% packet loss on custom bridge network).
 - Root cause: `iptables-nft` conflict with Docker — `DOCKER-ISOLATION-STAGE-2` chain missing, preventing any custom bridge network from being created. Neither Docker daemon restart nor manual chain creation resolved it.
 - Fix: switched `docker-compose.yml` to `network_mode: host` — bypasses Docker bridge networking entirely, appropriate for this single-container deployment. n8n now binds directly to host port 5678.
+- Tradeoffs of host mode: Linux-only behavior (Docker Desktop on macOS/Windows emulates via VM and may not expose the port identically), and the container shares the host's network namespace so there is no network isolation. Acceptable here: single-container deployment on a trusted Linux host. Bridge mode remains a drop-in alternative for other environments (see `docs/setup-n8n.md`).
 - Also removed deprecated `N8N_BASIC_AUTH_*` environment variables (removed in n8n v1.0, silently ignored by v2.14.2). Auth is now managed via n8n built-in user management.
 - Verified: container up, outbound connectivity OK, editor returns HTTP 200, Heartbeat workflow active and firing.
 - Remaining: Gmail OAuth refresh token is expired/revoked (independent of network incident) — requires re-authentication via Google Cloud Console.

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -1,11 +1,11 @@
-# n8n basic auth
-N8N_USER=admin
-N8N_PASSWORD=changeme
+# n8n authentication is managed via the built-in user management UI
+# on first launch (http://localhost:5678). No env vars required.
 
-# Gmail OAuth2 (configured in n8n credentials UI)
+# Gmail OAuth2 (configured in n8n credentials UI, kept here for reference)
 GMAIL_CLIENT_ID=
 GMAIL_CLIENT_SECRET=
 
-# Telegram Bot
+# Telegram Bot (token configured in n8n credentials UI)
+# TELEGRAM_CHAT_ID is read from rules/telegram-config.json at runtime.
 TELEGRAM_BOT_TOKEN=
 TELEGRAM_CHAT_ID=

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -2,12 +2,8 @@ services:
   n8n:
     image: n8nio/n8n:latest
     restart: unless-stopped
-    ports:
-      - "5678:5678"
+    network_mode: host
     environment:
-      - N8N_BASIC_AUTH_ACTIVE=true
-      - N8N_BASIC_AUTH_USER=${N8N_USER}
-      - N8N_BASIC_AUTH_PASSWORD=${N8N_PASSWORD}
       - GENERIC_TIMEZONE=Europe/Paris
       - TZ=Europe/Paris
       - N8N_RESTRICT_FILE_ACCESS_TO=/data/rules
@@ -15,11 +11,6 @@ services:
     volumes:
       - n8n_data:/home/node/.n8n
       - ../rules:/data/rules:ro
-    networks:
-      - n8n-net
 
 volumes:
   n8n_data:
-
-networks:
-  n8n-net:

--- a/docs/setup-n8n.md
+++ b/docs/setup-n8n.md
@@ -16,10 +16,6 @@ cp docker/.env.example docker/.env
 Edit `docker/.env` with your values:
 
 ```bash
-# n8n basic-auth credentials (used to access the n8n UI)
-N8N_USER=admin
-N8N_PASSWORD=your-strong-password
-
 # Gmail OAuth2 and Telegram credentials are configured directly
 # in the n8n UI (see steps 5 and 6 below), not via environment
 # variables. The following are kept here for reference only:
@@ -29,7 +25,30 @@ TELEGRAM_BOT_TOKEN=
 TELEGRAM_CHAT_ID=
 ```
 
+> **Authentication:** n8n v1.0+ uses built-in user management. On first launch, the UI prompts you to create an owner account — no env vars needed. The deprecated `N8N_BASIC_AUTH_*` variables are silently ignored by modern n8n versions.
+>
 > **Note:** The workflows read the Telegram chat ID from `rules/telegram-config.json`, not from `docker/.env`. The `TELEGRAM_CHAT_ID` entry in `.env` is for reference only.
+
+## Network Mode
+
+This deployment uses `network_mode: host` in `docker-compose.yml`. n8n binds directly to the host's port 5678.
+
+**Why host mode:**
+
+- Works around an `iptables-nft` conflict on some Linux hosts where Docker cannot create custom bridge networks (`DOCKER-ISOLATION-STAGE-2` chain missing).
+- Simpler setup for a single-container deployment.
+
+**Tradeoffs:**
+
+- **Linux only.** Host networking behaves differently on Docker Desktop for macOS/Windows — the container shares the host's network namespace on Linux, but Docker Desktop emulates this via a VM layer. On macOS/Windows you may need to switch to bridge mode.
+- **No network isolation.** The container shares the host's network stack. Acceptable here because n8n is the only service and runs on a trusted host.
+
+**To switch back to bridge networking** (e.g., on macOS/Windows, or if you don't hit the iptables issue), replace `network_mode: host` with:
+
+```yaml
+ports:
+  - "5678:5678"
+```
 
 ## 2. Create Telegram Bot and Get Chat ID
 
@@ -74,7 +93,7 @@ Edit `rules/telegram-config.json` with your chat ID:
 make up
 ```
 
-Open the UI at [http://localhost:5678](http://localhost:5678). On first launch, log in with the basic-auth credentials from `docker/.env`, then complete the n8n owner-account onboarding (using the same credentials or different ones).
+Open the UI at [http://localhost:5678](http://localhost:5678). On first launch, n8n prompts you to create an owner account (email + password) via its built-in user management.
 
 ## 4. Import Workflows
 


### PR DESCRIPTION
## Summary

- Fix Docker iptables-nft conflict that prevented any custom bridge network creation (`DOCKER-ISOLATION-STAGE-2` chain missing).
- Switch to `network_mode: host` — bypasses Docker bridge networking, appropriate for single-container deployment.
- Remove deprecated `N8N_BASIC_AUTH_*` env vars (removed in n8n v1.0, silently ignored by v2.14.2).
- Update `PROJECT_LOG.md` with incident details and fix rationale.

## Context

After a system state change, n8n became non-functional: editor unreachable (HTTP 000), Gmail Trigger failing with `'undefined'`, and 100% packet loss on outbound traffic from the container. Root cause: iptables-nft backend conflict with Docker's isolation chains. Neither daemon restart nor manual chain creation resolved it. Host network mode is the simplest, most reliable fix.

Remaining unresolved (independent): Gmail OAuth refresh token expired — requires re-authentication via Google Cloud Console.

## Checklist

- [x] JSON files are valid (`make validate`)
- [x] n8n editor accessible after fix (HTTP 200)
- [x] Heartbeat workflow active and firing
- [x] Docker compose starts without errors (`make up`)
- [x] No secrets or credentials committed