### PR TITLE
fix(n8n): filter Gmail Trigger to Launch-subject emails only

### DIFF
--- a/PROJECT_LOG.md
+++ b/PROJECT_LOG.md
@@ -215,3 +215,10 @@ All v1.0 issues closed (10/10). Repo public, workflows operational, post LinkedI
 - Diagnosis: DNS and HTTPS from the container are fine (Node `dns.resolve` + `https.get` to Gmail/Telegram both succeed); n8n logs show `fetch failed` / `DOMException TimeoutError` on PostHog feature-flag fetches — internal undici socket/keep-alive state got stale.
 - Fix: `docker compose restart n8n` flushes the socket pool and DNS cache. Editor back at HTTP 200, nodes retry cleanly.
 - No code change required — documented here so the symptom is recognizable next time.
+
+### Fix — Gmail Trigger filters non-Launch emails (Issue #25)
+
+- Symptom: the Parse Email node occasionally produced empty fields because non-Launch Kaggle emails (newsletters, community digests, product announcements) were also passing through the trigger.
+- Root cause: the Gmail Trigger only filtered on sender (`no-reply@kaggle.com`), not on subject. All Kaggle emails were pulled in, and the parser happily returned `Unknown`/`Not specified` for anything that wasn't a Launch announcement.
+- Fix: added `q: "subject:Launch"` to the Gmail Trigger's `filters` object. Gmail's search syntax is case-insensitive and matches both `"Competition Launch"` and `"Hackathon Launch"` subjects while rejecting everything else.
+- Committed in `workflows/kaggle-email-watcher.json` on branch `fix/gmail-subject-filter-launch` — will need a re-import in n8n UI after merge to take effect on the running workflow.

--- a/PROJECT_LOG.md
+++ b/PROJECT_LOG.md
@@ -220,5 +220,5 @@ All v1.0 issues closed (10/10). Repo public, workflows operational, post LinkedI
 
 - Symptom: the Parse Email node occasionally produced empty fields because non-Launch Kaggle emails (newsletters, community digests, product announcements) were also passing through the trigger.
 - Root cause: the Gmail Trigger only filtered on sender (`no-reply@kaggle.com`), not on subject. All Kaggle emails were pulled in, and the parser happily returned `Unknown`/`Not specified` for anything that wasn't a Launch announcement.
-- Fix: added `q: "subject:Launch"` to the Gmail Trigger's `filters` object. Gmail's search syntax is case-insensitive and matches both `"Competition Launch"` and `"Hackathon Launch"` subjects while rejecting everything else.
+- Fix: added `q: '(subject:"Competition Launch" OR subject:"Hackathon Launch")'` to the Gmail Trigger's `filters` object. Quoted phrase matching ensures only those two exact subjects reach the parser; broader forms like `subject:Launch` would still let through product-launch announcements and similar noise.
 - Committed in `workflows/kaggle-email-watcher.json` on branch `fix/gmail-subject-filter-launch` — will need a re-import in n8n UI after merge to take effect on the running workflow.

--- a/workflows/kaggle-email-watcher.json
+++ b/workflows/kaggle-email-watcher.json
@@ -13,7 +13,7 @@
         "simple": false,
         "filters": {
           "sender": "no-reply@kaggle.com",
-          "q": "subject:Launch"
+          "q": "(subject:\"Competition Launch\" OR subject:\"Hackathon Launch\")"
         },
         "options": {}
       },

--- a/workflows/kaggle-email-watcher.json
+++ b/workflows/kaggle-email-watcher.json
@@ -12,7 +12,8 @@
         },
         "simple": false,
         "filters": {
-          "sender": "no-reply@kaggle.com"
+          "sender": "no-reply@kaggle.com",
+          "q": "subject:Launch"
         },
         "options": {}
       },


### PR DESCRIPTION
## Summary

Adds `q: "subject:Launch"` to the Gmail Trigger's `filters` so the Kaggle Email Watcher only picks up **Competition Launch** and **Hackathon Launch** emails. All other Kaggle mail (newsletters, community digests, product announcements) is silently ignored.

**Before this PR:** sender-only filter — every Kaggle email reached `Parse Email`, producing empty alerts when the Launch-specific regexes didn't match.

**After:** Gmail's `subject:` operator (case-insensitive, substring match) matches both Launch-prefixed subjects and rejects everything else at the source.

## Checklist

- [x] JSON files are valid (`make validate`)
- [x] `make check` passes (JSON + YAML/shell/markdown lint)
- [x] No secrets committed (`gitleaks detect` — no leaks found)
- [x] Docker compose up and running
- [ ] **Post-merge:** re-import `workflows/kaggle-email-watcher.json` in n8n UI and Publish so the filter takes effect on the running workflow

Closes #25