### PR TITLE
fix(docker): override container resolv.conf to bypass systemd-resolved

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -11,6 +11,7 @@ services:
     volumes:
       - n8n_data:/home/node/.n8n
       - ../rules:/data/rules:ro
+      - ./resolv.conf:/etc/resolv.conf:ro
 
 volumes:
   n8n_data:

--- a/docker/resolv.conf
+++ b/docker/resolv.conf
@@ -1,0 +1,16 @@
+# DNS resolver for the n8n container.
+# Mounted into /etc/resolv.conf (read-only) by docker-compose.yml.
+#
+# Why: with network_mode: host, the container inherits the host's
+# /etc/resolv.conf which points to systemd-resolved (127.0.0.53).
+# Node.js / undici occasionally get stuck on EAI_AGAIN or ECONNRESET
+# when systemd-resolved has a transient issue, because Node's c-ares
+# resolver reads /etc/resolv.conf once and caches the failure until
+# the process is restarted. See GitHub issue #43.
+#
+# This file bypasses systemd-resolved entirely and points Node directly
+# at Cloudflare and Google public resolvers. Only the n8n container is
+# affected; the host's DNS configuration is untouched.
+nameserver 1.1.1.1
+nameserver 8.8.8.8
+options timeout:2 attempts:2

--- a/docker/resolv.conf
+++ b/docker/resolv.conf
@@ -3,7 +3,7 @@
 #
 # Why: with network_mode: host, the container inherits the host's
 # /etc/resolv.conf which points to systemd-resolved (127.0.0.53).
-# Node.js / undici occasionally get stuck on EAI_AGAIN or ECONNRESET
+# Node.js / undici occasionally get stuck on EAI_AGAIN DNS lookup failures
 # when systemd-resolved has a transient issue, because Node's c-ares
 # resolver reads /etc/resolv.conf once and caches the failure until
 # the process is restarted. See GitHub issue #43.
@@ -11,6 +11,15 @@
 # This file bypasses systemd-resolved entirely and points Node directly
 # at Cloudflare and Google public resolvers. Only the n8n container is
 # affected; the host's DNS configuration is untouched.
+#
+# Tradeoff: overriding /etc/resolv.conf here drops any host-provided
+# search domains and private/split-DNS resolvers (for example from VPNs
+# or corporate networks). Short internal hostnames and private zones may
+# stop resolving inside the container unless you customize this file.
+#
+# If you rely on internal DNS, replace/add the appropriate nameserver
+# entries for your environment and uncomment/configure a search domain:
+# search example.internal
 nameserver 1.1.1.1
 nameserver 8.8.8.8
 options timeout:2 attempts:2

--- a/docs/setup-n8n.md
+++ b/docs/setup-n8n.md
@@ -218,7 +218,9 @@ make check      # Run all checks (validate + lint)
   [issue #43](https://github.com/benoit-bremaud/n8n-kaggle-watcher/issues/43)
   so we can escalate to option A (Docker healthcheck + auto-restart) or
   option D (external log watcher).
-- **After changing `docker/resolv.conf`**: a plain `docker compose
-  restart n8n` is **not** enough — the bind mount is only evaluated at
-  container create time. Use `make down && make up` (or
-  `docker compose up -d --force-recreate n8n`) to pick up the new file.
+- **After editing `docker/resolv.conf`**: the updated file is visible
+  through the bind mount, so `docker compose restart n8n` is typically
+  enough to make n8n/Node re-read `/etc/resolv.conf`. You only need
+  `make down && make up` (or `docker compose up -d --force-recreate n8n`)
+  if you add or change the `/etc/resolv.conf` volume mount itself in
+  `docker-compose.yml`.

--- a/docs/setup-n8n.md
+++ b/docs/setup-n8n.md
@@ -196,3 +196,29 @@ make check      # Run all checks (validate + lint)
 - Check the workflow is published and active in n8n
 - Verify `rules/telegram-config.json` exists and contains your chat ID
 - Check timezone: n8n uses `Europe/Paris` (configured in docker-compose.yml)
+
+### `EAI_AGAIN` / `fetch failed` on Gmail or Telegram nodes
+
+- **Symptom**: Gmail Trigger or Telegram Send nodes fail with
+  `getaddrinfo EAI_AGAIN api.telegram.org` (or `gmail.googleapis.com`).
+  The n8n log also shows `TypeError: fetch failed` on PostHog telemetry
+  requests as a leading indicator.
+- **Root cause**: with `network_mode: host`, the container inherits the
+  host's `/etc/resolv.conf`, which points to `systemd-resolved`
+  (`127.0.0.53`). When systemd-resolved has a transient hiccup, Node's
+  c-ares resolver caches the failure for the lifetime of the process, so
+  every subsequent DNS lookup fails until the container restarts.
+- **Fix (shipped)**: `docker/resolv.conf` overrides the container's
+  resolver to Cloudflare (`1.1.1.1`) and Google (`8.8.8.8`), bypassing
+  systemd-resolved entirely. It is mounted read-only at
+  `/etc/resolv.conf` by `docker-compose.yml`. Only the n8n container is
+  affected — the host's DNS configuration is untouched.
+- **If the symptom still occurs**: run `docker compose restart n8n` as a
+  one-off, capture the logs, and open a follow-up referencing
+  [issue #43](https://github.com/benoit-bremaud/n8n-kaggle-watcher/issues/43)
+  so we can escalate to option A (Docker healthcheck + auto-restart) or
+  option D (external log watcher).
+- **After changing `docker/resolv.conf`**: a plain `docker compose
+  restart n8n` is **not** enough — the bind mount is only evaluated at
+  container create time. Use `make down && make up` (or
+  `docker compose up -d --force-recreate n8n`) to pick up the new file.


### PR DESCRIPTION
## Summary

Mounts a dedicated `docker/resolv.conf` (Cloudflare `1.1.1.1` + Google `8.8.8.8`) into the n8n container at `/etc/resolv.conf`, bypassing `systemd-resolved` (`127.0.0.53`) entirely. Only the container is affected — the host's DNS configuration is untouched.

**Context (issue #43):** under `network_mode: host`, the container inherits the host's resolver stub. When `systemd-resolved` has a transient hiccup, Node's c-ares resolver caches the failure for the lifetime of the process, so every subsequent lookup fails with `EAI_AGAIN` / `fetch failed` until the container is restarted. This manifested as a silent 3-day outage where Gmail Trigger, Telegram Send, **and** the Error Handler (also Telegram-based) were all unable to reach external hosts.

**Why this fix (option B from #43):** minimal surface, fully reversible, addresses the root cause (stub resolver dependency) without changing network topology or pinning a new n8n version. Options A (healthcheck + auto-restart) and D (external watcher) remain valuable complements and are tracked separately for follow-up.

**Also documents** the symptom, root cause, and the "recreate, not restart" caveat (bind mounts are evaluated at container create time) in `docs/setup-n8n.md` under Troubleshooting.

## Validation

- `docker exec docker-n8n-1 cat /etc/resolv.conf` → override applied despite `network_mode: host`
- `dns.resolve4` from Node inside the container → `api.telegram.org`, `gmail.googleapis.com`, `telemetry.n8n.io`, `us.i.posthog.com` all resolve
- First 90 seconds of logs after `make down && make up` → **zero** `EAI_AGAIN` / `fetch failed` / PostHog errors (vs. errors within 2s on the previous run)
- End-to-end: live Kaggle competition launch email → Gmail Trigger → rules engine → Telegram Send → notification received

## Checklist

- [x] JSON files are valid (`make validate`)
- [x] `make check` passes (JSON + YAML/shell/markdown lint)
- [x] n8n workflow still imports successfully (no workflow files touched)
- [x] Docker compose starts without errors (`make down && make up` validated)
- [x] No secrets or credentials committed

Refs #43