### PR TITLE
chore(docker): pin n8n image to 2.14.2 (#43 option C)

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   n8n:
-    image: n8nio/n8n:latest
+    image: n8nio/n8n:2.14.2
     restart: unless-stopped
     network_mode: host
     labels:


### PR DESCRIPTION
## Summary

Pins the n8n image tag in `docker/docker-compose.yml` from `latest` to `2.14.2` — the version already in production at the time of pinning.

**Why:** tracking `latest` means every `docker compose pull` (or fresh `make up` after image removal) silently rolls forward to whatever n8n has released, including breaking changes, DNS-related regressions, or altered telemetry behaviour. Issue #43 traced our 2026-04-20 silent outage to exactly this class of transient environmental surface. Pinning turns future upgrades into explicit PRs (version bump + test + changelog) rather than passive drift.

**Bump cadence:** manual for now — bump the pin in its own PR, validate with `make down && make up`, confirm healthcheck still green. Renovate/Dependabot can be added later if the bump rhythm becomes a chore.

## Scope

- One-line change. No workflow, rules, or doc touched.
- Closes **issue #43 option C**. Options A (shipped in #50) and B (shipped in #44) already in production. Option D (external watcher independent of Docker) is the last remaining item on #43.

## Validation

- `make down && make up` recreates the stack with the pinned image.
- `docker exec docker-n8n-1 n8n --version` → `2.14.2`.
- Healthcheck transitions to `healthy` on the first probe (t=1s), FailingStreak: 0.
- `autoheal` sidecar idle — no restart triggered.
- `make check` green (YAML, shell, markdown, JSON).

## Checklist

- [x] JSON files are valid (`make validate`)
- [x] `make check` passes
- [x] Docker compose starts cleanly (`make down && make up`)
- [x] n8n container reaches `healthy` with the pinned image
- [x] No secrets or credentials committed

Refs #43