### PR TITLE
feat(docker): external watchdog with heartbeat marker (#43 option D, closes #43)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,10 @@ rules/telegram-config.json
 # n8n data
 n8n_data/
 
+# Runtime state written by the Heartbeat workflow (read by the external
+# watchdog). The directory itself is tracked via state/.gitkeep.
+state/last-heartbeat
+
 # Node
 node_modules/
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,6 +113,37 @@ Before making the repository public, **all** of the following must be verified:
 - [ ] CI includes a secret detection job (gitleaks)
 - [ ] `make check` passes (JSON validation + lint)
 
+## Workflow Versioning Convention
+
+n8n's **Publish workflow** modal asks for a version name and an optional change description. Both are stored per-workflow in the n8n version history.
+
+**Version name format** — semver with a one-line description, separated by an em-dash:
+
+```
+vX.Y.Z — <imperative short description, sentence case, no trailing period>
+```
+
+Bump rules (per workflow, independent of the repo's git tag versioning):
+
+- **MAJOR** — breaking change to the workflow contract (renamed input/output fields, removed credentials, changed trigger type)
+- **MINOR** — new node, new branch in the flow, new external dependency
+- **PATCH** — bug fix, parameter tweak, message wording change, no structural change
+
+Examples:
+
+- `v1.0.0 — Initial publish`
+- `v1.1.0 — Disable n8n attribution`
+- `v1.2.0 — Write heartbeat marker for external watchdog`
+- `v1.2.1 — Fix marker file path typo`
+
+**Change description format** — a tight paragraph (2–4 sentences) explaining:
+
+1. What was added / changed (concrete: which node, which field)
+2. Why (the user-facing motivation, link to issue if relevant)
+3. Any operator-visible impact (e.g. "requires `make down && make up` to pick up new env var")
+
+The published version names are visible in the **Version History** side panel inside n8n and double as a per-workflow changelog. Keep them stable enough that scrolling through them tells the story of the workflow's evolution without needing to open each diff.
+
 ## Workflow Export Convention
 
 When exporting workflows from n8n to commit in git:

--- a/Makefile
+++ b/Makefile
@@ -39,8 +39,13 @@ install-watchdog: ## Install external watchdog (user systemd timer)
 	@echo "  Last run:  systemctl --user status n8n-watchdog.service"
 	@echo "  Manual:    $(WATCHDOG_BIN)"
 	@if [ ! -f "$(WATCHDOG_ENV_DIR)/env" ]; then \
-		echo "⚠ Create $(WATCHDOG_ENV_DIR)/env with TELEGRAM_BOT_TOKEN and TELEGRAM_CHAT_ID."; \
+		echo "⚠ Create $(WATCHDOG_ENV_DIR)/env with TELEGRAM_BOT_TOKEN, TELEGRAM_CHAT_ID and STATE_DIR."; \
 		echo "  See docs/setup-n8n.md → External Watchdog."; \
+	fi
+	@if [ "$$(loginctl show-user "$$USER" -p Linger --value 2>/dev/null)" != "yes" ]; then \
+		echo "⚠ Linger is not enabled for $$USER — the user systemd manager (and this timer) only runs while you are logged in."; \
+		echo "  After a reboot without an interactive login, the watchdog will be silent until next login."; \
+		echo "  Enable lingering once (requires sudo): sudo loginctl enable-linger $$USER"; \
 	fi
 
 uninstall-watchdog: ## Uninstall external watchdog (keeps env file)

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,10 @@
-.PHONY: up down logs validate lint check help
+.PHONY: up down logs validate lint check install-watchdog uninstall-watchdog help
 
 COMPOSE := docker compose -f docker/docker-compose.yml --env-file docker/.env
+
+WATCHDOG_BIN := $(HOME)/.local/bin/n8n-watchdog
+SYSTEMD_USER_DIR := $(HOME)/.config/systemd/user
+WATCHDOG_ENV_DIR := $(HOME)/.config/n8n-watchdog
 
 help: ## Show available commands
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | \
@@ -22,3 +26,26 @@ lint: ## Run linters (yaml, shell, markdown)
 	@bash scripts/lint.sh
 
 check: validate lint ## Run all checks (validate + lint)
+
+install-watchdog: ## Install external watchdog (user systemd timer)
+	@install -d $(dir $(WATCHDOG_BIN)) $(SYSTEMD_USER_DIR)
+	@install -m 755 scripts/watchdog.sh $(WATCHDOG_BIN)
+	@install -m 644 scripts/n8n-watchdog.service $(SYSTEMD_USER_DIR)/n8n-watchdog.service
+	@install -m 644 scripts/n8n-watchdog.timer $(SYSTEMD_USER_DIR)/n8n-watchdog.timer
+	@systemctl --user daemon-reload
+	@systemctl --user enable --now n8n-watchdog.timer
+	@echo "✓ Watchdog installed and timer enabled."
+	@echo "  Status:    systemctl --user status n8n-watchdog.timer"
+	@echo "  Last run:  systemctl --user status n8n-watchdog.service"
+	@echo "  Manual:    $(WATCHDOG_BIN)"
+	@if [ ! -f "$(WATCHDOG_ENV_DIR)/env" ]; then \
+		echo "⚠ Create $(WATCHDOG_ENV_DIR)/env with TELEGRAM_BOT_TOKEN and TELEGRAM_CHAT_ID."; \
+		echo "  See docs/setup-n8n.md → External Watchdog."; \
+	fi
+
+uninstall-watchdog: ## Uninstall external watchdog (keeps env file)
+	-@systemctl --user disable --now n8n-watchdog.timer 2>/dev/null || true
+	-@rm -f $(SYSTEMD_USER_DIR)/n8n-watchdog.service $(SYSTEMD_USER_DIR)/n8n-watchdog.timer
+	-@rm -f $(WATCHDOG_BIN)
+	@systemctl --user daemon-reload
+	@echo "✓ Watchdog uninstalled. Env file at $(WATCHDOG_ENV_DIR)/env left in place."

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -8,7 +8,8 @@ services:
     environment:
       - GENERIC_TIMEZONE=Europe/Paris
       - TZ=Europe/Paris
-      - N8N_RESTRICT_FILE_ACCESS_TO=/data/rules,/data/state
+      - N8N_RESTRICT_FILE_ACCESS_TO=/data
+      - NODE_FUNCTION_ALLOW_BUILTIN=fs
       - TELEGRAM_CHAT_ID=${TELEGRAM_CHAT_ID}
     volumes:
       - n8n_data:/home/node/.n8n

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -8,11 +8,12 @@ services:
     environment:
       - GENERIC_TIMEZONE=Europe/Paris
       - TZ=Europe/Paris
-      - N8N_RESTRICT_FILE_ACCESS_TO=/data/rules
+      - N8N_RESTRICT_FILE_ACCESS_TO=/data/rules,/data/state
       - TELEGRAM_CHAT_ID=${TELEGRAM_CHAT_ID}
     volumes:
       - n8n_data:/home/node/.n8n
       - ../rules:/data/rules:ro
+      - ../state:/data/state
       - ./resolv.conf:/etc/resolv.conf:ro
     healthcheck:
       test:

--- a/docs/setup-n8n.md
+++ b/docs/setup-n8n.md
@@ -248,16 +248,35 @@ third probe stays active.
 # 1. Create the env file (chmod 600, kept outside the repo)
 mkdir -p ~/.config/n8n-watchdog
 cat > ~/.config/n8n-watchdog/env <<'EOF'
-TELEGRAM_BOT_TOKEN=123456:abc...           # same bot used by n8n
-TELEGRAM_CHAT_ID=123456789                 # same chat id
+# Required: bot credentials for the alert channel
+TELEGRAM_BOT_TOKEN=123456:abc...                  # same bot used by n8n
+TELEGRAM_CHAT_ID=123456789                        # same chat id
+
+# Required: absolute path of the state/ directory on the host
+# (matches the bind mount in docker/docker-compose.yml)
 STATE_DIR=/home/vev/Documents/07_kaggle/n8n-kaggle-watcher/state
-MARKER_CHECK_ENABLED=1                     # 0 only as an escape hatch (see above)
+
+# Optional: set 0 to skip the heartbeat marker check (escape hatch)
+MARKER_CHECK_ENABLED=1
 EOF
 chmod 600 ~/.config/n8n-watchdog/env
 
 # 2. Install the script + systemd user units, enable the timer
 make install-watchdog
 ```
+
+**Lingering (one-time, recommended on any host that will be left
+unattended after a reboot — Pi, headless server, machine you do not
+log into immediately):**
+
+```bash
+sudo loginctl enable-linger "$USER"
+```
+
+User systemd timers only run while a user session is active. Without
+lingering, the watchdog stops monitoring after a reboot until you log
+in again — defeating the purpose of an always-on detection layer.
+`make install-watchdog` warns when this is not set.
 
 ### Verify
 

--- a/docs/setup-n8n.md
+++ b/docs/setup-n8n.md
@@ -237,10 +237,10 @@ sends a recovery notice when it recovers:
    (catches a deactivated workflow, expired credential, or any reason
    the heartbeat stops firing without crashing the container).
 
-The marker check is opt-in via `MARKER_CHECK_ENABLED=1` in the env
-file. Until the Heartbeat workflow is updated to write the marker (see
-the workflow notes in `workflows/heartbeat.json`), leave it at `0` to
-avoid false positives.
+The marker check is gated by `MARKER_CHECK_ENABLED=1` in the env file.
+Set it to `0` only as an escape hatch if the marker file is intentionally
+absent (e.g. during a workflow rebuild) — otherwise leave it on so the
+third probe stays active.
 
 ### Setup
 
@@ -251,7 +251,7 @@ cat > ~/.config/n8n-watchdog/env <<'EOF'
 TELEGRAM_BOT_TOKEN=123456:abc...           # same bot used by n8n
 TELEGRAM_CHAT_ID=123456789                 # same chat id
 STATE_DIR=/home/vev/Documents/07_kaggle/n8n-kaggle-watcher/state
-MARKER_CHECK_ENABLED=0                     # flip to 1 once the workflow writes the marker
+MARKER_CHECK_ENABLED=1                     # 0 only as an escape hatch (see above)
 EOF
 chmod 600 ~/.config/n8n-watchdog/env
 

--- a/docs/setup-n8n.md
+++ b/docs/setup-n8n.md
@@ -215,7 +215,82 @@ trigger an automatic restart with no human intervention.
   nor `autoheal` has anything left to act on. Detecting an explicitly
   stopped-but-still-existing container (for example via
   `docker compose stop` / `docker stop`) requires an external watcher
-  independent of Docker (tracked as issue #43 option D).
+  independent of Docker (see **External Watchdog** below).
+
+## External Watchdog
+
+A host-side watchdog (`scripts/watchdog.sh`) probes the n8n stack from
+**outside Docker** and posts a Telegram alert directly — independent of
+n8n itself, so it stays usable when n8n is down, the container is
+removed, or DNS is broken inside the container. Runs on a `systemd`
+user timer every 15 minutes.
+
+It runs three checks; each one alerts once when it starts failing and
+sends a recovery notice when it recovers:
+
+1. **Container running** — `docker inspect` shows `running` for
+   `docker-n8n-1` (catches `make down` / `docker stop` / engine crash).
+2. **Container health** — Docker reports `healthy` (catches stuck
+   probes that autoheal failed to recover).
+3. **Heartbeat marker freshness** — `state/last-heartbeat` (written by
+   the Heartbeat workflow on every successful run) is younger than 26 h
+   (catches a deactivated workflow, expired credential, or any reason
+   the heartbeat stops firing without crashing the container).
+
+The marker check is opt-in via `MARKER_CHECK_ENABLED=1` in the env
+file. Until the Heartbeat workflow is updated to write the marker (see
+the workflow notes in `workflows/heartbeat.json`), leave it at `0` to
+avoid false positives.
+
+### Setup
+
+```bash
+# 1. Create the env file (chmod 600, kept outside the repo)
+mkdir -p ~/.config/n8n-watchdog
+cat > ~/.config/n8n-watchdog/env <<'EOF'
+TELEGRAM_BOT_TOKEN=123456:abc...           # same bot used by n8n
+TELEGRAM_CHAT_ID=123456789                 # same chat id
+STATE_DIR=/home/vev/Documents/07_kaggle/n8n-kaggle-watcher/state
+MARKER_CHECK_ENABLED=0                     # flip to 1 once the workflow writes the marker
+EOF
+chmod 600 ~/.config/n8n-watchdog/env
+
+# 2. Install the script + systemd user units, enable the timer
+make install-watchdog
+```
+
+### Verify
+
+```bash
+# Manual one-shot run (should exit 0 silently when everything is fine)
+~/.local/bin/n8n-watchdog && echo OK
+
+# Timer state and next firing time
+systemctl --user list-timers n8n-watchdog.timer
+
+# Last service run (logs, exit code)
+systemctl --user status n8n-watchdog.service
+journalctl --user -u n8n-watchdog.service -n 20
+
+# Trigger a controlled failure: stop n8n and wait <= 15 min for the alert.
+# After `make up`, the next watchdog run posts a recovery message.
+make down
+```
+
+### Anti-spam
+
+Each check writes a sentinel under `/tmp/n8n-watchdog-alerted-<check>`
+after sending an alert and only re-alerts once that sentinel is
+removed (which happens automatically when the check passes again). One
+issue → one alert + one recovery notice, regardless of how many timer
+ticks the failure spans.
+
+### Uninstall
+
+```bash
+make uninstall-watchdog       # removes script, units, disables timer
+rm -rf ~/.config/n8n-watchdog # only if you also want to wipe the secrets
+```
 
 ## Troubleshooting
 

--- a/scripts/n8n-watchdog.service
+++ b/scripts/n8n-watchdog.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=n8n external watchdog (probe + Telegram alert)
+Documentation=https://github.com/benoit-bremaud/n8n-kaggle-watcher
+After=docker.service
+Wants=docker.service
+
+[Service]
+Type=oneshot
+ExecStart=%h/.local/bin/n8n-watchdog
+# Surface failures in the journal but keep the timer alive on errors.
+SuccessExitStatus=0 1

--- a/scripts/n8n-watchdog.service
+++ b/scripts/n8n-watchdog.service
@@ -1,8 +1,11 @@
 [Unit]
 Description=n8n external watchdog (probe + Telegram alert)
 Documentation=https://github.com/benoit-bremaud/n8n-kaggle-watcher
-After=docker.service
-Wants=docker.service
+# Note: this is a user systemd unit and cannot order against the
+# system-level docker.service. The script itself probes the Docker
+# daemon first and alerts distinctly when it is unreachable, so the
+# watchdog stays useful even if Docker is not yet ready when the
+# timer fires.
 
 [Service]
 Type=oneshot

--- a/scripts/n8n-watchdog.timer
+++ b/scripts/n8n-watchdog.timer
@@ -1,0 +1,14 @@
+[Unit]
+Description=Run n8n external watchdog every 15 minutes
+Documentation=https://github.com/benoit-bremaud/n8n-kaggle-watcher
+
+[Timer]
+# First run shortly after the user session starts, then every 15 minutes.
+OnBootSec=2min
+OnUnitActiveSec=15min
+Unit=n8n-watchdog.service
+AccuracySec=30s
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/scripts/watchdog.sh
+++ b/scripts/watchdog.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# n8n external watchdog
+#
+# Probes the n8n stack from outside Docker and alerts via Telegram
+# when the container is missing, unhealthy, or has stopped firing the
+# daily Heartbeat workflow. Designed to be run on a systemd timer
+# every 15 minutes (see scripts/n8n-watchdog.timer).
+#
+# Configuration is read from ${WATCHDOG_ENV_FILE:-$HOME/.config/n8n-watchdog/env}.
+# Required variables:
+#   TELEGRAM_BOT_TOKEN     bot token used to post the alert
+#   TELEGRAM_CHAT_ID       chat id receiving the alert
+# Optional variables (with defaults):
+#   CONTAINER_NAME         docker container name        (default: docker-n8n-1)
+#   STATE_DIR              host path of the state mount (default: derived from script location)
+#   MARKER_FILE_NAME       marker file inside STATE_DIR (default: last-heartbeat)
+#   MARKER_MAX_AGE_SECONDS marker freshness threshold   (default: 93600 = 26 h)
+#   MARKER_CHECK_ENABLED   1 to enable marker check     (default: 0 — flipped on once the
+#                                                        Heartbeat workflow writes the marker)
+#   SENTINEL_DIR           dir holding per-check anti-spam sentinels (default: /tmp)
+
+set -euo pipefail
+
+WATCHDOG_ENV_FILE="${WATCHDOG_ENV_FILE:-$HOME/.config/n8n-watchdog/env}"
+
+if [ ! -r "$WATCHDOG_ENV_FILE" ]; then
+  echo "watchdog: env file not found or not readable: $WATCHDOG_ENV_FILE" >&2
+  exit 2
+fi
+
+# shellcheck source=/dev/null
+. "$WATCHDOG_ENV_FILE"
+
+: "${TELEGRAM_BOT_TOKEN:?TELEGRAM_BOT_TOKEN must be set in $WATCHDOG_ENV_FILE}"
+: "${TELEGRAM_CHAT_ID:?TELEGRAM_CHAT_ID must be set in $WATCHDOG_ENV_FILE}"
+
+CONTAINER_NAME="${CONTAINER_NAME:-docker-n8n-1}"
+MARKER_FILE_NAME="${MARKER_FILE_NAME:-last-heartbeat}"
+MARKER_MAX_AGE_SECONDS="${MARKER_MAX_AGE_SECONDS:-93600}"
+MARKER_CHECK_ENABLED="${MARKER_CHECK_ENABLED:-0}"
+SENTINEL_DIR="${SENTINEL_DIR:-/tmp}"
+
+if [ -z "${STATE_DIR:-}" ]; then
+  # Default: <repo>/state, derived from the script's location.
+  script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+  STATE_DIR="$(cd -- "$script_dir/.." && pwd)/state"
+fi
+
+send_telegram() {
+  local text="$1"
+  # --fail makes curl exit non-zero on 4xx/5xx so a bad token, revoked
+  # bot, or Telegram outage does NOT create a sentinel — the next
+  # watchdog tick will retry the alert.
+  curl --silent --show-error --fail --max-time 10 \
+    --data-urlencode "chat_id=${TELEGRAM_CHAT_ID}" \
+    --data-urlencode "text=${text}" \
+    --data-urlencode "parse_mode=Markdown" \
+    "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
+    >/dev/null
+}
+
+# alert_once <check_id> <message> — sends a Telegram alert at most once per
+# failure streak. The sentinel file is removed by clear_alert when the check
+# recovers, so the next failure can alert again.
+alert_once() {
+  local check_id="$1"
+  local message="$2"
+  local sentinel="${SENTINEL_DIR}/n8n-watchdog-alerted-${check_id}"
+  if [ -f "$sentinel" ]; then
+    return 0
+  fi
+  if send_telegram "$message"; then
+    : >"$sentinel"
+  fi
+}
+
+# clear_alert <check_id> [recovery_message] — if a sentinel exists for this
+# check, removes it and (if a message was provided) sends a recovery notice.
+clear_alert() {
+  local check_id="$1"
+  local recovery_message="${2:-}"
+  local sentinel="${SENTINEL_DIR}/n8n-watchdog-alerted-${check_id}"
+  if [ ! -f "$sentinel" ]; then
+    return 0
+  fi
+  rm -f "$sentinel"
+  if [ -n "$recovery_message" ]; then
+    send_telegram "$recovery_message" || true
+  fi
+}
+
+check_container_running() {
+  local status
+  status="$(docker inspect --format '{{.State.Status}}' "$CONTAINER_NAME" 2>/dev/null || echo "missing")"
+  if [ "$status" = "running" ]; then
+    clear_alert "container" "✅ *n8n watchdog* — container \`${CONTAINER_NAME}\` is back to *running*."
+    return 0
+  fi
+  alert_once "container" "🚨 *n8n watchdog* — container \`${CONTAINER_NAME}\` is *${status}* (expected: running). The next Heartbeat will not fire until this is resolved."
+  return 1
+}
+
+check_container_health() {
+  local health
+  health="$(docker inspect --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}' "$CONTAINER_NAME" 2>/dev/null || echo "missing")"
+  case "$health" in
+    healthy|starting|none)
+      clear_alert "health" "✅ *n8n watchdog* — container health is back to *${health}*."
+      return 0
+      ;;
+    unhealthy)
+      alert_once "health" "🚨 *n8n watchdog* — container \`${CONTAINER_NAME}\` is *unhealthy*. autoheal should restart it shortly; if this alert persists, the restart is failing."
+      return 1
+      ;;
+    *)
+      alert_once "health" "🚨 *n8n watchdog* — container \`${CONTAINER_NAME}\` health is unknown (\`${health}\`). Check the container state manually."
+      return 1
+      ;;
+  esac
+}
+
+check_heartbeat_marker() {
+  if [ "$MARKER_CHECK_ENABLED" != "1" ]; then
+    return 0
+  fi
+  local marker="${STATE_DIR}/${MARKER_FILE_NAME}"
+  if [ ! -f "$marker" ]; then
+    alert_once "marker" "🚨 *n8n watchdog* — heartbeat marker \`${marker}\` is missing. The Heartbeat workflow has not run since the last reset, or the volume mount is broken."
+    return 1
+  fi
+  local mtime now age
+  mtime="$(stat -c %Y "$marker")"
+  now="$(date +%s)"
+  age=$(( now - mtime ))
+  if [ "$age" -gt "$MARKER_MAX_AGE_SECONDS" ]; then
+    local hours=$(( age / 3600 ))
+    alert_once "marker" "🚨 *n8n watchdog* — heartbeat marker is *${hours}h* old (threshold: $(( MARKER_MAX_AGE_SECONDS / 3600 ))h). The Heartbeat workflow has stopped firing — check it is published and active in n8n."
+    return 1
+  fi
+  clear_alert "marker" "✅ *n8n watchdog* — heartbeat marker is fresh again."
+  return 0
+}
+
+# Run all checks. Each check is independent: a failure on one does not skip
+# the others, so a single watchdog tick can surface multiple issues.
+overall=0
+check_container_running || overall=1
+check_container_health  || overall=1
+check_heartbeat_marker  || overall=1
+
+exit "$overall"

--- a/scripts/watchdog.sh
+++ b/scripts/watchdog.sh
@@ -40,11 +40,13 @@ MARKER_MAX_AGE_SECONDS="${MARKER_MAX_AGE_SECONDS:-93600}"
 MARKER_CHECK_ENABLED="${MARKER_CHECK_ENABLED:-0}"
 SENTINEL_DIR="${SENTINEL_DIR:-/tmp}"
 
-if [ -z "${STATE_DIR:-}" ]; then
-  # Default: <repo>/state, derived from the script's location.
-  script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
-  STATE_DIR="$(cd -- "$script_dir/.." && pwd)/state"
-fi
+# STATE_DIR must be set explicitly. A previous version derived a default
+# from the script's location, but `make install-watchdog` copies the
+# script to ~/.local/bin, which would then resolve STATE_DIR to a wrong
+# path and surface false "marker missing" alerts. Forcing the operator
+# to set it makes the install path obvious and matches the env-file
+# template documented in docs/setup-n8n.md.
+: "${STATE_DIR:?STATE_DIR must be set in $WATCHDOG_ENV_FILE (absolute path to the host-side state directory containing the heartbeat marker)}"
 
 send_telegram() {
   local text="$1"

--- a/scripts/watchdog.sh
+++ b/scripts/watchdog.sh
@@ -89,6 +89,20 @@ clear_alert() {
   fi
 }
 
+check_docker_daemon() {
+  # Probe the daemon explicitly so we can distinguish "container is gone"
+  # from "Docker is unreachable" (daemon down, socket missing, no perms).
+  # Without this, every check below would say "container missing" — which
+  # would be misleading since the operator should restart Docker, not the
+  # container.
+  if docker info >/dev/null 2>&1; then
+    clear_alert "daemon" "✅ *n8n watchdog* — Docker daemon is reachable again."
+    return 0
+  fi
+  alert_once "daemon" "🚨 *n8n watchdog* — Docker daemon is *unreachable* (\`docker info\` failed). Container, health, and heartbeat checks were skipped this tick. Restart Docker (\`sudo systemctl restart docker\`) or check user permissions."
+  return 1
+}
+
 check_container_running() {
   local status
   status="$(docker inspect --format '{{.State.Status}}' "$CONTAINER_NAME" 2>/dev/null || echo "missing")"
@@ -104,9 +118,22 @@ check_container_health() {
   local health
   health="$(docker inspect --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}' "$CONTAINER_NAME" 2>/dev/null || echo "missing")"
   case "$health" in
-    healthy|starting|none)
-      clear_alert "health" "✅ *n8n watchdog* — container health is back to *${health}*."
+    healthy)
+      clear_alert "health" "✅ *n8n watchdog* — container health is back to *healthy*."
       return 0
+      ;;
+    starting)
+      # Transient state during boot or autoheal recovery — neither alert
+      # nor recovery. The next tick will re-evaluate.
+      return 0
+      ;;
+    none)
+      # No healthcheck configured. Either the docker-compose.yml lost its
+      # `healthcheck:` block or someone is running an out-of-tree image.
+      # Either way the second probe of this watchdog is now ineffective,
+      # so flag it loudly.
+      alert_once "health" "🚨 *n8n watchdog* — container \`${CONTAINER_NAME}\` has *no Docker healthcheck configured* (status: \`none\`). The watchdog cannot verify that n8n becomes *healthy*. Restore the \`healthcheck:\` block in docker-compose.yml."
+      return 1
       ;;
     unhealthy)
       alert_once "health" "🚨 *n8n watchdog* — container \`${CONTAINER_NAME}\` is *unhealthy*. autoheal should restart it shortly; if this alert persists, the restart is failing."
@@ -141,8 +168,16 @@ check_heartbeat_marker() {
   return 0
 }
 
-# Run all checks. Each check is independent: a failure on one does not skip
-# the others, so a single watchdog tick can surface multiple issues.
+# Probe the Docker daemon first. If it is unreachable, every downstream
+# check would surface a misleading "container missing" — short-circuit
+# instead so the operator sees the actual root cause (daemon down).
+if ! check_docker_daemon; then
+  exit 1
+fi
+
+# Each container-level check is independent: a failure on one does not
+# skip the others, so a single watchdog tick can surface multiple
+# distinct issues.
 overall=0
 check_container_running || overall=1
 check_container_health  || overall=1

--- a/workflows/heartbeat.json
+++ b/workflows/heartbeat.json
@@ -72,6 +72,19 @@
       ],
       "id": "56d8ed96-5b15-4f7f-a8e0-9a41a143f5ea",
       "name": "Inject Chat ID"
+    },
+    {
+      "parameters": {
+        "jsCode": "require('fs').writeFileSync('/data/state/last-heartbeat', new Date().toISOString());\nreturn $input.all();\n"
+      },
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        880,
+        0
+      ],
+      "id": "0b6ea5f6-a3d3-425f-b324-f7a67e155293",
+      "name": "Write Heartbeat Marker"
     }
   ],
   "pinData": {},
@@ -103,6 +116,17 @@
         [
           {
             "node": "Send a text message",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Send a text message": {
+      "main": [
+        [
+          {
+            "node": "Write Heartbeat Marker",
             "type": "main",
             "index": 0
           }


### PR DESCRIPTION
## Summary

Closes the last open lever of issue #43 — the silent stop. After PR #44 (DNS resolver), PR #50 (healthcheck + autoheal), and PR #52 (pin n8n version), the only failure mode that still escaped detection was a workflow that quietly stopped firing for any reason internal to n8n (workflow toggled off, credential expired, container removed by an explicit `docker compose down`). This PR adds a host-side watchdog that probes the n8n stack from **outside Docker** every 15 minutes and posts a Telegram alert directly — independent of n8n itself, so it stays usable when n8n is gone.

The watchdog mirrors the user-perceptible signal: *"did the daily heartbeat arrive?"* Three independent checks:

1. Container is `running` (`docker inspect`)
2. Docker reports `healthy` (catches stuck probes that autoheal failed to recover)
3. `state/last-heartbeat` marker file is younger than 26 h (catches a deactivated workflow, a credential rotation, or any internal failure that does not crash the container)

Each check is one alert per failure streak with a recovery notice when it clears.

## Architecture, in two parts

**Part A — `8519368` — host scaffolding (no n8n change)**

| File | Role |
|---|---|
| `scripts/watchdog.sh` | Three probes, sentinel-based anti-spam in `/tmp`, `curl --fail` so a failed delivery does not silently mark the alert as sent |
| `scripts/n8n-watchdog.service` + `.timer` | systemd user units, 15-min interval, persistent across reboots |
| `docker/docker-compose.yml` | New bind mount `../state:/data/state` (rw); `state/.gitkeep` tracks the directory while `state/last-heartbeat` is gitignored |
| `Makefile` | `install-watchdog` / `uninstall-watchdog` targets |
| `docs/setup-n8n.md` | New "External Watchdog" section: env file template, install/test/uninstall procedure |

**Part B — `1cfc658` — workflow + env wiring + the convention we picked up**

| File | Role |
|---|---|
| `workflows/heartbeat.json` | Heartbeat v1.2.0 — adds a Code node `Write Heartbeat Marker` after Send Telegram, writing `new Date().toISOString()` to `/data/state/last-heartbeat` |
| `docker/docker-compose.yml` | `NODE_FUNCTION_ALLOW_BUILTIN=fs` (n8n CE blocks builtin Node modules in Code nodes by default); `N8N_RESTRICT_FILE_ACCESS_TO=/data` (n8n 2.14.2 does not parse separators in this var, so a single common parent is the only working shape — read-only protection on `/data/rules` is enforced by the Docker bind mount, not by n8n) |
| `docs/setup-n8n.md` | Env template defaults `MARKER_CHECK_ENABLED=1` |
| `CONTRIBUTING.md` | New "Workflow Versioning Convention" — captures the `vX.Y.Z — <description>` format used in n8n's Publish modal that emerged during this PR, with bump rules and change-description shape |

## Scope and closure

- **Closes #43.** Options A (PR #50), B (PR #44), C (PR #52), and D (this PR) all shipped.
- The full silence detection chain is now: n8n's healthcheck (catches DNS/HTTPS issues) → autoheal sidecar (restarts on unhealthy) → external watchdog (catches everything autoheal cannot, including a stopped container or a deactivated workflow).
- Out of scope: deport of the watchdog to a second host (Tier 4 — would require #37 Pi 5 migration first).

## Validation performed locally

- `make down && make up` recreates the stack with the new mount and env vars; both containers reach `healthy` on the first probe (~1 s).
- Bidirectional state mount confirmed: container writes to `/data/state`, host reads instantly from `state/`.
- `Test workflow` in n8n UI executes Schedule → Read Config → Inject Chat ID → Send Telegram (notification received) → Write Heartbeat Marker; `state/last-heartbeat` is written with a fresh ISO timestamp.
- Workflow re-published as v1.2.0 in n8n UI; exported with `--published` flag, sanitized through the project's `jq` filter, diff against previous committed version is exactly the new node + its connection.
- Watchdog smoke-tested with `MARKER_CHECK_ENABLED=1` and a fresh marker: exit 0 silently, no sentinel created, no Telegram call.
- Failure-mode dry run with a fake bot token and `--fail`: curl returns 22, sentinel is **not** created, the next watchdog tick will retry the alert.
- `make check` green (yamllint, shellcheck on `watchdog.sh` + project scripts, markdownlint, JSON validation).

## Operator install steps (post-merge, on the homelab host)

```bash
# 1. Create the watchdog env file (chmod 600, kept outside the repo)
mkdir -p ~/.config/n8n-watchdog
cat > ~/.config/n8n-watchdog/env <<ENV
TELEGRAM_BOT_TOKEN=<same bot used by n8n>
TELEGRAM_CHAT_ID=<same chat id>
STATE_DIR=/home/vev/Documents/07_kaggle/n8n-kaggle-watcher/state
MARKER_CHECK_ENABLED=1
ENV
chmod 600 ~/.config/n8n-watchdog/env

# 2. Install the script + systemd user units, enable the 15-min timer
make install-watchdog
```

## Checklist

- [x] JSON files are valid (`make validate`)
- [x] `make check` passes (JSON + YAML/shell/markdown lint)
- [x] Docker compose starts both services without errors
- [x] n8n container reaches `healthy` on a fresh start
- [x] Heartbeat workflow re-imported, re-published, marker file written end-to-end
- [x] Watchdog smoke-tested with marker check enabled, all checks pass silently
- [x] No secrets or credentials committed (Heartbeat JSON sanitized via the documented `jq` filter)

Closes #43
