### PR TITLE
chore(infra): setup ngrok tunnel for Telegram webhook (#30)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,11 +41,14 @@ flowchart LR
 
 Any failed production execution of **Kaggle Email Watcher** or **Heartbeat** triggers the **Error Handler** workflow, which sends a Telegram alert with the workflow name, failing node, error message, and timestamp.
 
+The Compose stack also runs an `autoheal` sidecar that restarts the n8n container if its Docker healthcheck fails, plus an `ngrok` tunnel that exposes `localhost:5678` publicly so Telegram inline-button callbacks can reach n8n (see [docs/setup-ngrok.md](docs/setup-ngrok.md)). A host-side `systemd` watchdog probes the stack from outside Docker and posts Telegram alerts directly when the container is missing, unhealthy, or has stopped firing the daily heartbeat (see [docs/setup-n8n.md → External Watchdog](docs/setup-n8n.md#external-watchdog)).
+
 ## Prerequisites
 
 - [Docker](https://docs.docker.com/get-docker/) and Docker Compose
 - Gmail account with API access ([setup guide](docs/setup-gmail-oauth.md))
 - Telegram Bot token ([setup guide](docs/setup-n8n.md#2-create-telegram-bot-and-get-chat-id))
+- Free [ngrok](https://dashboard.ngrok.com/signup) account for the public webhook tunnel ([setup guide](docs/setup-ngrok.md))
 
 ## Quick Start
 

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -9,3 +9,9 @@ GMAIL_CLIENT_SECRET=
 # TELEGRAM_CHAT_ID is read from rules/telegram-config.json at runtime.
 TELEGRAM_BOT_TOKEN=
 TELEGRAM_CHAT_ID=
+
+# ngrok tunnel (free tier) — exposes localhost:5678 publicly so
+# Telegram can deliver inline-button callback_query events.
+# Get a free token at https://dashboard.ngrok.com/get-started/your-authtoken
+# See docs/setup-ngrok.md for the full setup.
+NGROK_AUTHTOKEN=

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -35,5 +35,17 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
 
+  ngrok:
+    image: ngrok/ngrok:latest
+    restart: unless-stopped
+    # Match the n8n service so the tunnel target stays a simple
+    # localhost:5678 and ngrok's local inspector API on port 4040 is
+    # reachable from the host (used by the future webhook-updater
+    # sidecar in #31).
+    network_mode: host
+    command: http --log=stdout 5678
+    environment:
+      - NGROK_AUTHTOKEN=${NGROK_AUTHTOKEN}
+
 volumes:
   n8n_data:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -36,7 +36,7 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
 
   ngrok:
-    image: ngrok/ngrok:latest
+    image: ngrok/ngrok:3.38.0-debian
     restart: unless-stopped
     # Match the n8n service so the tunnel target stays a simple
     # localhost:5678 and ngrok's local inspector API on port 4040 is
@@ -45,7 +45,10 @@ services:
     network_mode: host
     command: http --log=stdout 5678
     environment:
-      - NGROK_AUTHTOKEN=${NGROK_AUTHTOKEN}
+      # Fail fast at compose-time when the operator forgot to set
+      # NGROK_AUTHTOKEN in docker/.env, rather than starting the
+      # container with an empty token and looping on auth errors.
+      - NGROK_AUTHTOKEN=${NGROK_AUTHTOKEN:?NGROK_AUTHTOKEN must be set in docker/.env (see docs/setup-ngrok.md)}
 
 volumes:
   n8n_data:

--- a/docs/setup-ngrok.md
+++ b/docs/setup-ngrok.md
@@ -1,0 +1,111 @@
+# ngrok tunnel — public URL for Telegram webhook
+
+## Why this exists
+
+Telegram inline-button taps are delivered as `callback_query` HTTP POST
+requests to a public URL the operator registers via the Bot API
+`setWebhook` endpoint. n8n runs on `localhost:5678` (host networking),
+which is not reachable from Telegram's servers. ngrok punches a public
+tunnel from `https://<random>.ngrok-free.app` straight to that local
+port, so the callback chain works without exposing the host's port to
+the internet directly.
+
+This is the v1.2 prototype tunnel. The roadmap migrates to
+**Cloudflare Tunnel** in v1.3 (stable URL, no per-restart rotation,
+zero-trust auth) and to a self-hosted reverse proxy in v3.0 once the
+stack moves to the homelab Pi.
+
+## Operator setup (one-time)
+
+1. **Create a free ngrok account** at
+   https://dashboard.ngrok.com/signup. The free tier is sufficient for
+   prototyping (1 concurrent tunnel, random subdomain per session).
+2. **Copy the authtoken** from
+   https://dashboard.ngrok.com/get-started/your-authtoken.
+3. **Set it in `docker/.env`**:
+
+   ```bash
+   echo "NGROK_AUTHTOKEN=<your-token>" >> docker/.env
+   ```
+
+   `docker/.env` is gitignored; the placeholder lives in
+   `docker/.env.example` for documentation.
+
+4. **Recreate the stack** so the new env var reaches the ngrok
+   container:
+
+   ```bash
+   make down && make up
+   ```
+
+The `ngrok` service runs alongside `n8n` and `autoheal` on the same
+host network. It restarts automatically (`restart: unless-stopped`)
+and tears down with `make down`.
+
+## Verify the tunnel works
+
+```bash
+# 1. Service is up
+docker ps --filter "name=docker-ngrok-1" --format "{{.Names}}\t{{.Status}}"
+
+# 2. Read the current public URL from ngrok's local inspector API
+PUBLIC_URL=$(curl -s http://localhost:4040/api/tunnels | jq -r '.tunnels[0].public_url')
+echo "$PUBLIC_URL"
+# expected: https://<random>.ngrok-free.app
+
+# 3. Hit n8n's healthcheck endpoint through the tunnel
+curl -i "$PUBLIC_URL/healthz"
+# expected: HTTP 200 with {"status":"ok"} (or similar n8n health body)
+```
+
+If step 3 returns 200, the chain Telegram → ngrok → n8n is reachable
+end-to-end at the network layer. Wiring the actual Telegram webhook
+to this URL is handled by issue #31 (callback handler workflow).
+
+## Free-tier limitations
+
+- **URL rotates on every restart.** The hostname looks like
+  `https://abc123-xyz.ngrok-free.app` and changes every time the
+  ngrok container is recreated. From #31 onwards, a webhook-updater
+  sidecar will re-register the new URL with the Telegram Bot API on
+  every `make up`, so the rotation is transparent. Until then, the
+  URL is informational.
+- **Interstitial warning page** on first browser visit per session.
+  This affects humans browsing to the URL, **not** Telegram's
+  webhook delivery (which the warning page does not gate).
+- **40 concurrent connections** and **bandwidth limits** — way above
+  anything our use case will reach (a few callback POSTs per day).
+
+## Troubleshooting
+
+### `docker logs docker-ngrok-1` shows `ERR_NGROK_4018` or `authentication failed`
+
+The authtoken is wrong, missing, or for a different account. Double-
+check `docker/.env`, then `make down && make up`.
+
+### `curl http://localhost:4040/api/tunnels` returns "connection refused"
+
+ngrok is not running or its inspector API has not started yet. Wait
+~3 seconds after `make up`, or check `docker logs docker-ngrok-1` for
+errors (often a bad authtoken or an account-level limit hit).
+
+### `curl $PUBLIC_URL/healthz` returns 200 but Telegram delivery fails
+
+The tunnel is fine — the issue is one layer up. Check that the bot
+token is correct, that `setWebhook` was called with the right URL,
+and that `getWebhookInfo` shows no `last_error_message`. These are
+#31 territory.
+
+## Stop / disable the tunnel
+
+```bash
+# Tear down everything
+make down
+
+# Or temporarily stop just ngrok without affecting n8n
+docker stop docker-ngrok-1
+```
+
+`make up` brings it back next time. To remove the tunnel from the
+stack entirely (e.g. when migrating to Cloudflare Tunnel in v1.3),
+delete the `ngrok` service block in `docker/docker-compose.yml`.

--- a/docs/setup-ngrok.md
+++ b/docs/setup-ngrok.md
@@ -18,10 +18,10 @@ stack moves to the homelab Pi.
 ## Operator setup (one-time)
 
 1. **Create a free ngrok account** at
-   https://dashboard.ngrok.com/signup. The free tier is sufficient for
+   <https://dashboard.ngrok.com/signup>. The free tier is sufficient for
    prototyping (1 concurrent tunnel, random subdomain per session).
 2. **Copy the authtoken** from
-   https://dashboard.ngrok.com/get-started/your-authtoken.
+   <https://dashboard.ngrok.com/get-started/your-authtoken>.
 3. **Set it in `docker/.env`**:
 
    ```bash
@@ -48,10 +48,13 @@ and tears down with `make down`.
 # 1. Service is up
 docker ps --filter "name=docker-ngrok-1" --format "{{.Names}}\t{{.Status}}"
 
-# 2. Read the current public URL from ngrok's local inspector API
-PUBLIC_URL=$(curl -s http://localhost:4040/api/tunnels | jq -r '.tunnels[0].public_url')
+# 2. Read the current HTTPS public URL from ngrok's local inspector API.
+# Filter explicitly on `proto == "https"` rather than taking .tunnels[0]:
+# Telegram requires HTTPS for webhooks, and when ngrok exposes both http
+# and https tunnels their order is not guaranteed.
+PUBLIC_URL=$(curl -s http://localhost:4040/api/tunnels | jq -r '.tunnels[] | select(.proto == "https") | .public_url')
 echo "$PUBLIC_URL"
-# expected: https://<random>.ngrok-free.app
+# expected: https://<random>.ngrok-free.dev
 
 # 3. Hit n8n's healthcheck endpoint through the tunnel
 curl -i "$PUBLIC_URL/healthz"
@@ -94,7 +97,7 @@ errors (often a bad authtoken or an account-level limit hit).
 The tunnel is fine — the issue is one layer up. Check that the bot
 token is correct, that `setWebhook` was called with the right URL,
 and that `getWebhookInfo` shows no `last_error_message`. These are
-#31 territory.
+issue #31 territory.
 
 ## Stop / disable the tunnel
 


### PR DESCRIPTION
## Summary

Adds a public-tunnel service alongside n8n + autoheal so Telegram inline-button `callback_query` events (epic #45) have a reachable endpoint to deliver to. n8n itself stays on `localhost:5678` (host networking) — only ngrok faces the public internet. This is the **v1.2 prototype** tunnel; migration to Cloudflare Tunnel for stable URL + zero-trust auth is the v1.3 roadmap item.

## Changes

| File | Change |
|---|---|
| `docker/docker-compose.yml` | New `ngrok` service. `ngrok/ngrok:latest`, `restart: unless-stopped`, `network_mode: host` so the tunnel target is a simple `localhost:5678` and the local inspector API on port 4040 is reachable from the host (the discovery mechanism #31 will use). Auth via `NGROK_AUTHTOKEN` env var. |
| `docker/.env.example` | `NGROK_AUTHTOKEN=` placeholder + 3-line comment pointing to the ngrok dashboard signup + token retrieval flow. |
| `docs/setup-ngrok.md` | New operator guide: why the tunnel exists, signup walkthrough, expected URL-rotates-on-restart behavior, troubleshooting (`ERR_NGROK_4018`, inspector API unreachable, webhook delivery failures), how to stop/disable. |
| `README.md` | Brief mention in the architecture section + ngrok signup added to prerequisites with a link to the new doc. |

## Scope

- **Closes #30.** Tunnel running, public URL reaches n8n, setup documented — all acceptance criteria met.
- **Strictly out of scope (deferred to #31):** the Telegram Bot API `setWebhook` call. Adding that now would point Telegram at a non-existent endpoint since no Telegram Trigger workflow exists yet. The webhook-updater sidecar that handles the rotation transparently ships with #31 alongside the trigger workflow it serves.

## Validation performed locally

- `make down && make up` brings up `n8n` + `autoheal` + `ngrok` cleanly. All three reach their respective ready/healthy states.
- `docker logs docker-ngrok-1` shows the expected sequence: `client session established` → `tunnel session started` → `started tunnel ... url=https://laboring-laziness-generic.ngrok-free.dev`.
- `curl http://localhost:4040/api/tunnels` returns the public URL via ngrok's local inspector API. This is the programmatic discovery path the future webhook-updater will use.
- `curl https://<public-url>/healthz` returns `HTTP/2 200` with `{"status":"ok"}` from n8n — proving end-to-end public reachability through the tunnel: external HTTPS → ngrok edge → tunnel → n8n.
- `make check` green (yamllint on the updated compose, markdownlint, no shell scripts touched in this PR).

## Operator setup (one-time, after merge)

```bash
# 1. Sign up at https://dashboard.ngrok.com/signup (free tier sufficient)
# 2. Copy the authtoken from https://dashboard.ngrok.com/get-started/your-authtoken
# 3. Append to docker/.env (gitignored):
echo 'NGROK_AUTHTOKEN=<your-token>' >> docker/.env

# 4. Recreate the stack so the new env var reaches the ngrok container:
make down && make up
```

Documented at greater length with troubleshooting in `docs/setup-ngrok.md`.

## Security note

Once the tunnel is up, n8n is reachable at the random `https://<...>.ngrok-free.dev` URL. Existing protections:

- n8n's built-in user management (operator-set password at first launch) protects the editor, the REST API, and any non-webhook endpoint.
- Webhook endpoints generated by n8n use unpredictable 32-char IDs.
- The free-tier ngrok URL rotates on every container restart, shrinking the exposure window of any leaked URL.

The acceptable-tradeoff envelope is "single-user homelab prototype". The v1.3 Cloudflare Tunnel migration will tighten this with a stable URL behind zero-trust auth.

## Checklist

- [x] JSON files are valid (`make validate` — no JSON files touched in this PR but still green)
- [x] `make check` passes (YAML + markdown lint)
- [x] Docker compose starts the new service without errors (validated locally)
- [x] Public URL reaches n8n's `/healthz` end-to-end
- [x] No secrets or credentials committed (`docker/.env` stays gitignored, only the placeholder lives in `.env.example`)

Closes #30
Part of epic #45
