### PR TITLE
feat(n8n): Telegram callback handler — sidecar + router workflow

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -40,8 +40,8 @@ services:
     restart: unless-stopped
     # Match the n8n service so the tunnel target stays a simple
     # localhost:5678 and ngrok's local inspector API on port 4040 is
-    # reachable from the host (used by the future webhook-updater
-    # sidecar in #31).
+    # reachable from the host (used by the webhook-updater sidecar
+    # below).
     network_mode: host
     command: http --log=stdout 5678
     environment:
@@ -49,6 +49,27 @@ services:
       # NGROK_AUTHTOKEN in docker/.env, rather than starting the
       # container with an empty token and looping on auth errors.
       - NGROK_AUTHTOKEN=${NGROK_AUTHTOKEN:?NGROK_AUTHTOKEN must be set in docker/.env (see docs/setup-ngrok.md)}
+
+  webhook-updater:
+    image: alpine:3.20
+    # `restart: on-failure` so the script retries if ngrok was not yet
+    # ready or Telegram briefly returned an error. Once successful the
+    # script exits 0 and the container stops cleanly — Compose treats
+    # exit 0 as terminal success and does not loop.
+    restart: on-failure
+    # Same network as ngrok so localhost:4040 (the ngrok inspector
+    # API) is reachable.
+    network_mode: host
+    depends_on:
+      - ngrok
+    environment:
+      - TELEGRAM_BOT_TOKEN=${TELEGRAM_BOT_TOKEN:?TELEGRAM_BOT_TOKEN must be set in docker/.env}
+      # WEBHOOK_PATH must match the path of the Webhook node in
+      # workflows/telegram-callback-handler.json (Partie B of #31).
+      - WEBHOOK_PATH=/webhook/telegram-callback
+    volumes:
+      - ../scripts/update-telegram-webhook.sh:/opt/update-webhook.sh:ro
+    command: sh -c 'apk add --no-cache curl jq >/dev/null && /opt/update-webhook.sh'
 
 volumes:
   n8n_data:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -65,7 +65,7 @@ services:
     environment:
       - TELEGRAM_BOT_TOKEN=${TELEGRAM_BOT_TOKEN:?TELEGRAM_BOT_TOKEN must be set in docker/.env}
       # WEBHOOK_PATH must match the path of the Webhook node in
-      # workflows/telegram-callback-handler.json (Partie B of #31).
+      # workflows/telegram-callback-handler.json (Part B of #31).
       - WEBHOOK_PATH=/webhook/telegram-callback
     volumes:
       - ../scripts/update-telegram-webhook.sh:/opt/update-webhook.sh:ro

--- a/docs/setup-n8n.md
+++ b/docs/setup-n8n.md
@@ -311,6 +311,89 @@ make uninstall-watchdog       # removes script, units, disables timer
 rm -rf ~/.config/n8n-watchdog # only if you also want to wipe the secrets
 ```
 
+## Telegram Webhook Auto-Registration
+
+The `webhook-updater` Compose sidecar registers the Telegram Bot API
+webhook URL automatically every time the stack starts, so the
+ngrok-rotated public URL is always in sync with what Telegram knows
+about. This means inline-button `callback_query` events are routed
+back to n8n without any operator action after `make up`.
+
+How it works:
+
+1. Sidecar boots after the `ngrok` service, installs `curl` + `jq`
+   (Alpine image), then runs [`scripts/update-telegram-webhook.sh`](../scripts/update-telegram-webhook.sh).
+2. Polls `http://localhost:4040/api/tunnels` until ngrok exposes its
+   HTTPS tunnel (max 30 attempts, 2s apart).
+3. Calls Telegram `setWebhook` with the URL
+   `<ngrok-public-url>/webhook/telegram-callback` and
+   `allowed_updates=["callback_query"]` so unrelated bot updates
+   (chat messages, forwards) do not hit the handler.
+4. Verifies via `getWebhookInfo` that the URL was accepted.
+5. Exits 0; Compose stops the container cleanly.
+
+Required env (read from `docker/.env`):
+
+- `TELEGRAM_BOT_TOKEN` — same bot used by the notification workflows.
+
+Optional overrides (set as Compose env on the `webhook-updater`
+service if needed): `WEBHOOK_PATH`, `NGROK_API`, `MAX_ATTEMPTS`,
+`SLEEP_BETWEEN`. See the script header for defaults.
+
+### Verify the webhook is registered with Telegram
+
+```bash
+# Reads the bot token from docker/.env, asks Telegram what URL it has
+set -a && . docker/.env && set +a
+curl -s "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/getWebhookInfo" | jq .
+unset TELEGRAM_BOT_TOKEN
+```
+
+Expected `result.url` should be `https://<random>.ngrok-free.dev/webhook/telegram-callback`. Expected `result.allowed_updates` should be `["callback_query"]`.
+
+### Simulate a callback locally (no Telegram needed)
+
+Useful before the inline buttons (#27) ship — proves the handler
+chain works end-to-end without going through the Telegram client.
+
+```bash
+# Reach the handler through the public ngrok URL, just like Telegram would
+PUBLIC_URL=$(curl -s http://localhost:4040/api/tunnels | jq -r '.tunnels[] | select(.proto == "https") | .public_url')
+
+curl -is -X POST "$PUBLIC_URL/webhook/telegram-callback" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "update_id": 1,
+    "callback_query": {
+      "id": "test-callback-id",
+      "from": { "id": 1, "first_name": "Test" },
+      "data": "action=skip&competition_id=titanic"
+    }
+  }'
+```
+
+- **Before the handler workflow exists** (no Webhook node registered):
+  expect `HTTP 404` with body `{"code":404,"message":"The requested
+  webhook \"POST telegram-callback\" is not registered."}`. This still
+  proves the network path Telegram → ngrok → n8n is reachable.
+- **After the handler workflow is active**: expect `HTTP 200` and an
+  execution visible in n8n's Executions list, with the Switch node
+  routed to the right branch based on `data`.
+
+### Webhook is not being delivered to n8n
+
+Debug ladder, in order:
+
+1. `docker logs docker-webhook-updater-1` — did the sidecar succeed
+   on the last `make up`? Look for `✓ getWebhookInfo confirms URL`.
+2. `getWebhookInfo` (above) — does Telegram report a recent
+   `last_error_message`? Common ones: `Bad Request: bad webhook`
+   (URL is wrong shape), `Wrong response from the webhook` (n8n
+   workflow returned non-2xx).
+3. `docker logs docker-ngrok-1` — is the tunnel still up?
+4. Manually re-run the script:
+   `docker compose -f docker/docker-compose.yml --env-file docker/.env run --rm webhook-updater`.
+
 ## Troubleshooting
 
 ### "chat not found" when testing Telegram

--- a/docs/setup-n8n.md
+++ b/docs/setup-n8n.md
@@ -367,7 +367,7 @@ chain works end-to-end without going through the Telegram client.
 
 ```bash
 # Reach the handler through the public ngrok URL, just like Telegram would
-PUBLIC_URL=$(curl -s http://localhost:4040/api/tunnels | jq -r '.tunnels[] | select(.proto == "https") | .public_url')
+PUBLIC_URL=$(curl -s http://localhost:4040/api/tunnels | jq -r '[.tunnels[] | select(.proto == "https") | .public_url][0]')
 
 curl -is -X POST "$PUBLIC_URL/webhook/telegram-callback" \
   -H 'Content-Type: application/json' \

--- a/docs/setup-n8n.md
+++ b/docs/setup-n8n.md
@@ -97,7 +97,7 @@ Open the UI at [http://localhost:5678](http://localhost:5678). On first launch, 
 
 ## 4. Import Workflows
 
-Three workflows need to be imported:
+Four workflows need to be imported:
 
 ### Kaggle Email Watcher (main workflow)
 
@@ -116,10 +116,17 @@ Three workflows need to be imported:
 2. Select `workflows/error-handler.json`
 3. Publish the workflow so it is available as a target
 
-Then link it as the error workflow of the other two:
+### Telegram Callback Handler (router for inline-button clicks)
+
+1. Click **Add workflow** → menu `⋮` → **Import from file**
+2. Select `workflows/telegram-callback-handler.json`
+3. The workflow defines a Webhook trigger on `POST /webhook/telegram-callback` — the path the `webhook-updater` sidecar registers with Telegram on every `make up`
+
+Then link the Error Handler as the error workflow of the other three:
 
 1. Open **Heartbeat** → menu `⋮` → **Settings** → **Error Workflow** → select **Error Handler** → **Save**
 2. Open **Kaggle Email Watcher** → menu `⋮` → **Settings** → **Error Workflow** → select **Error Handler** → **Save**
+3. Open **Telegram Callback Handler** → menu `⋮` → **Settings** → **Error Workflow** → select **Error Handler** → **Save**
 
 Any failed production execution will now trigger a Telegram alert with the workflow name, failing node, error message, and timestamp (Europe/Paris).
 
@@ -151,9 +158,11 @@ For each workflow:
 
 1. Open the workflow
 2. Click **Publish** (top right)
-3. The schedule triggers will start running:
-   - **Heartbeat**: every day at 07:55 (confirms n8n is alive)
-   - **Kaggle Email Watcher**: every day at 08:00 (checks Gmail for Kaggle emails)
+3. The triggers will start running:
+   - **Heartbeat**: scheduled every day at 07:55 (confirms n8n is alive)
+   - **Kaggle Email Watcher**: scheduled every day at 08:00 (checks Gmail for Kaggle emails)
+   - **Telegram Callback Handler**: webhook trigger on `POST /webhook/telegram-callback` — fires every time a user clicks an inline button on a Kaggle event notification (gated on #27 for the buttons themselves to ship)
+   - **Error Handler**: triggered automatically when any of the three above throws — no schedule of its own
 
 ## 7. Verify
 
@@ -367,10 +376,18 @@ curl -is -X POST "$PUBLIC_URL/webhook/telegram-callback" \
     "callback_query": {
       "id": "test-callback-id",
       "from": { "id": 1, "first_name": "Test" },
+      "message": { "message_id": 42, "chat": { "id": 99 } },
       "data": "action=skip&competition_id=titanic"
     }
   }'
 ```
+
+The `message.message_id` and `message.chat.id` fields mirror the shape
+of a real Telegram `callback_query` payload — the `Parse Callback Data`
+Code node extracts them so downstream branches (#46, #28) can edit the
+original message in place and dispatch to the right chat. They are
+optional for the routing test but should be included to keep the
+simulated payload faithful.
 
 - **Before the handler workflow exists** (no Webhook node registered):
   expect `HTTP 404` with body `{"code":404,"message":"The requested
@@ -378,7 +395,23 @@ curl -is -X POST "$PUBLIC_URL/webhook/telegram-callback" \
   proves the network path Telegram → ngrok → n8n is reachable.
 - **After the handler workflow is active**: expect `HTTP 200` and an
   execution visible in n8n's Executions list, with the Switch node
-  routed to the right branch based on `data`.
+  routed to the right branch based on `data` — `action=join` →
+  `Answer Join`, `action=skip` → `Answer Skip`, anything else →
+  `Answer Unknown`. Each branch calls `answerCallbackQuery` to dismiss
+  the Telegram spinner with a short confirmation
+  (`✅ Joining…` / `❌ Skipping…` / `⚠️ Unknown action`).
+- **Expected side effects of the simulated test**: the `Answer*` nodes
+  will return a Telegram error (`Bad Request: query is too old or
+  invalid`) because the fake `callback_query.id` does not exist on
+  Telegram's side. This is correct behavior — the failure propagates
+  to the global Error Handler, which sends one Telegram alert per
+  call. Real button clicks from Telegram supply a valid `id` and
+  succeed silently.
+- **What the handler does NOT do yet**: write to `state/watchlist.json`
+  (owned by #46 / #28), call any downstream workflow, mark the source
+  email as read, or edit the original Telegram message. The current
+  scope is strictly the router skeleton — the action branches will be
+  grafted onto the Switch outputs in #46 and #28.
 
 ### Webhook is not being delivered to n8n
 

--- a/scripts/update-telegram-webhook.sh
+++ b/scripts/update-telegram-webhook.sh
@@ -1,0 +1,109 @@
+#!/bin/sh
+# Telegram webhook updater — runs as a one-shot Docker sidecar at stack
+# startup. Polls the local ngrok inspector API for the current public
+# URL, then registers it with the Telegram Bot API via setWebhook so
+# inline-button callback_query events are routed back to n8n.
+#
+# Why this exists
+#   ngrok free-tier rotates the public URL on every container restart.
+#   Without this script, the operator would have to manually re-call
+#   setWebhook after every `make up`. With it, registration is fully
+#   automated and the only operator state is the single bot token in
+#   docker/.env.
+#
+# Required env
+#   TELEGRAM_BOT_TOKEN   bot token used to call the Bot API
+#
+# Optional env (with defaults)
+#   WEBHOOK_PATH         path appended to the ngrok URL when registering
+#                        (default: /webhook/telegram-callback — matches
+#                        the Webhook node path in
+#                        workflows/telegram-callback-handler.json)
+#   NGROK_API            ngrok local inspector URL
+#                        (default: http://localhost:4040/api/tunnels)
+#   MAX_ATTEMPTS         polling attempts on the ngrok API
+#                        (default: 30 — at 2s each = 1 minute total)
+#   SLEEP_BETWEEN        seconds between polling attempts (default: 2)
+#
+# Exit codes
+#   0  webhook successfully registered (or already registered with the
+#      same URL — Telegram is idempotent on setWebhook)
+#   1  unrecoverable failure: ngrok never came up, Telegram returned
+#      ok=false, or the verification getWebhookInfo did not match
+#      (Compose `restart: on-failure` will retry up to its policy)
+
+set -eu
+
+: "${TELEGRAM_BOT_TOKEN:?TELEGRAM_BOT_TOKEN must be set}"
+WEBHOOK_PATH="${WEBHOOK_PATH:-/webhook/telegram-callback}"
+NGROK_API="${NGROK_API:-http://localhost:4040/api/tunnels}"
+MAX_ATTEMPTS="${MAX_ATTEMPTS:-30}"
+SLEEP_BETWEEN="${SLEEP_BETWEEN:-2}"
+
+echo "webhook-updater starting"
+echo "  ngrok API:      $NGROK_API"
+echo "  webhook path:   $WEBHOOK_PATH"
+echo "  max attempts:   $MAX_ATTEMPTS (sleep ${SLEEP_BETWEEN}s)"
+
+# 1. Wait for ngrok to expose its HTTPS tunnel.
+PUBLIC_URL=""
+attempt=1
+while [ "$attempt" -le "$MAX_ATTEMPTS" ]; do
+  RESPONSE="$(curl -fsS --max-time 3 "$NGROK_API" 2>/dev/null || true)"
+  if [ -n "$RESPONSE" ]; then
+    PUBLIC_URL="$(printf '%s' "$RESPONSE" | jq -r '.tunnels[]? | select(.proto == "https") | .public_url' 2>/dev/null | head -1)"
+    if [ -n "$PUBLIC_URL" ] && [ "$PUBLIC_URL" != "null" ]; then
+      echo "Got public URL on attempt $attempt: $PUBLIC_URL"
+      break
+    fi
+  fi
+  echo "  attempt $attempt/$MAX_ATTEMPTS — ngrok not ready, retrying in ${SLEEP_BETWEEN}s"
+  attempt=$((attempt + 1))
+  sleep "$SLEEP_BETWEEN"
+done
+
+if [ -z "$PUBLIC_URL" ] || [ "$PUBLIC_URL" = "null" ]; then
+  echo "ERROR: failed to obtain ngrok public URL after $MAX_ATTEMPTS attempts" >&2
+  exit 1
+fi
+
+# 2. Register the webhook with Telegram.
+WEBHOOK_URL="${PUBLIC_URL}${WEBHOOK_PATH}"
+echo "Registering Telegram webhook: $WEBHOOK_URL"
+
+# Restrict allowed_updates to callback_query so unrelated bot updates
+# (chat messages, forwards, etc.) do not hit our handler unexpectedly.
+SET_RESPONSE="$(curl -fsS --max-time 10 \
+  --data-urlencode "url=$WEBHOOK_URL" \
+  --data-urlencode 'allowed_updates=["callback_query"]' \
+  "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/setWebhook")"
+
+OK="$(printf '%s' "$SET_RESPONSE" | jq -r '.ok')"
+if [ "$OK" != "true" ]; then
+  echo "ERROR: Telegram setWebhook returned ok=false" >&2
+  printf '%s' "$SET_RESPONSE" | jq . >&2 || printf '%s' "$SET_RESPONSE" >&2
+  exit 1
+fi
+
+DESCRIPTION="$(printf '%s' "$SET_RESPONSE" | jq -r '.description // empty')"
+echo "✓ setWebhook ok: $DESCRIPTION"
+
+# 3. Verify via getWebhookInfo.
+INFO="$(curl -fsS --max-time 10 "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/getWebhookInfo")"
+ACTUAL_URL="$(printf '%s' "$INFO" | jq -r '.result.url')"
+if [ "$ACTUAL_URL" = "$WEBHOOK_URL" ]; then
+  echo "✓ getWebhookInfo confirms URL: $ACTUAL_URL"
+else
+  echo "ERROR: getWebhookInfo URL mismatch" >&2
+  echo "  expected: $WEBHOOK_URL" >&2
+  echo "  actual:   $ACTUAL_URL" >&2
+  exit 1
+fi
+
+LAST_ERROR="$(printf '%s' "$INFO" | jq -r '.result.last_error_message // empty')"
+if [ -n "$LAST_ERROR" ]; then
+  echo "WARNING: Telegram reports a previous delivery error: $LAST_ERROR" >&2
+fi
+
+echo "webhook-updater done"
+exit 0

--- a/workflows/telegram-callback-handler.json
+++ b/workflows/telegram-callback-handler.json
@@ -1,0 +1,235 @@
+{
+  "name": "Telegram Callback Handler",
+  "nodes": [
+    {
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "telegram-callback",
+        "options": {}
+      },
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2.1,
+      "position": [
+        0,
+        0
+      ],
+      "id": "b0ba9b65-42ce-411a-8fd7-5b1d024e8cb1",
+      "name": "Telegram Callback Webhook",
+      "webhookId": "YOUR_WEBHOOK_ID"
+    },
+    {
+      "parameters": {
+        "jsCode": "// Parse the Telegram callback_query payload posted by the Webhook node.\n// Expected callback_data format: \"action=<join|skip>&competition_id=<slug>\"\n// We pull a few extra fields (callback_query_id, chat_id, message_id) that\n// downstream branches will need to call answerCallbackQuery and to edit\n// the original message in #27/#46/#28.\n\nconst body = $input.first().json.body;\n\nif (!body || !body.callback_query) {\n  throw new Error('Missing callback_query in webhook payload — not a Telegram callback POST?');\n}\n\nconst cb = body.callback_query;\nconst rawData = cb.data || '';\n\n// Parse \"key=value&key=value\" manually. URLSearchParams would also work at\n// runtime, but n8n's Code node TS checker doesn't recognize it and shows a\n// false-positive \"Cannot find name\" squiggle. The manual reduce below is\n// equivalent and stays clean in the editor.\nconst params = Object.fromEntries(\n  rawData\n    .split('&')\n    .filter(Boolean)\n    .map((pair) => {\n      const [key, ...valueParts] = pair.split('=');\n      return [\n        decodeURIComponent(key),\n        decodeURIComponent(valueParts.join('=')),\n      ];\n    })\n);\n\nconst action = params.action || 'unknown';\nconst competitionId = params.competition_id || '';\n\nreturn [\n  {\n    json: {\n      action,\n      competition_id: competitionId,\n      callback_query_id: cb.id,\n      chat_id: cb.message?.chat?.id,\n      message_id: cb.message?.message_id,\n      from_user_id: cb.from?.id,\n      from_first_name: cb.from?.first_name,\n      raw_data: rawData,\n    },\n  },\n];\n"
+      },
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        208,
+        0
+      ],
+      "id": "2f06d0f2-22d5-45a5-a874-9806f3ab8b4f",
+      "name": "Parse Callback Data"
+    },
+    {
+      "parameters": {
+        "rules": {
+          "values": [
+            {
+              "conditions": {
+                "options": {
+                  "caseSensitive": true,
+                  "leftValue": "",
+                  "typeValidation": "strict",
+                  "version": 3
+                },
+                "conditions": [
+                  {
+                    "leftValue": "=={{ $json.action }}",
+                    "rightValue": "join",
+                    "operator": {
+                      "type": "string",
+                      "operation": "equals"
+                    },
+                    "id": "850e2115-d0b1-4dc1-918e-b8d4d111df34"
+                  }
+                ],
+                "combinator": "and"
+              },
+              "renameOutput": true,
+              "outputKey": "join"
+            },
+            {
+              "conditions": {
+                "options": {
+                  "caseSensitive": true,
+                  "leftValue": "",
+                  "typeValidation": "strict",
+                  "version": 3
+                },
+                "conditions": [
+                  {
+                    "id": "6603ba66-31b6-4186-a9cd-50c70c15b3dd",
+                    "leftValue": "= ={{ $json.action }}",
+                    "rightValue": "skip",
+                    "operator": {
+                      "type": "string",
+                      "operation": "equals",
+                      "name": "filter.operator.equals"
+                    }
+                  }
+                ],
+                "combinator": "and"
+              },
+              "renameOutput": true,
+              "outputKey": "skip"
+            }
+          ]
+        },
+        "options": {
+          "fallbackOutput": "extra"
+        }
+      },
+      "type": "n8n-nodes-base.switch",
+      "typeVersion": 3.4,
+      "position": [
+        416,
+        0
+      ],
+      "id": "5d9f8a95-5462-4ef1-b9f9-8265ce02d85a",
+      "name": "Route by Action"
+    },
+    {
+      "parameters": {
+        "resource": "callback",
+        "queryId": "=={{ $json.callback_query_id }}",
+        "additionalFields": {
+          "text": "✅ Joining…"
+        }
+      },
+      "type": "n8n-nodes-base.telegram",
+      "typeVersion": 1.2,
+      "position": [
+        624,
+        -112
+      ],
+      "id": "534458fa-7640-4b19-8a45-b4352bec9b35",
+      "name": "Answer Join",
+      "webhookId": "YOUR_WEBHOOK_ID",
+      "credentials": {
+        "telegramApi": {
+          "id": "YOUR_CREDENTIAL_ID",
+          "name": "Telegram account"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "resource": "callback",
+        "queryId": "=={{ $json.callback_query_id }}",
+        "additionalFields": {
+          "text": "❌ Skipping…"
+        }
+      },
+      "type": "n8n-nodes-base.telegram",
+      "typeVersion": 1.2,
+      "position": [
+        624,
+        0
+      ],
+      "id": "40424679-76db-45c6-8dbf-2205d2fb3ca1",
+      "name": "Answer Skip",
+      "webhookId": "YOUR_WEBHOOK_ID",
+      "credentials": {
+        "telegramApi": {
+          "id": "YOUR_CREDENTIAL_ID",
+          "name": "Telegram account"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "resource": "callback",
+        "queryId": "=={{ $json.callback_query_id }}",
+        "additionalFields": {
+          "text": "⚠️ Unknown action"
+        }
+      },
+      "type": "n8n-nodes-base.telegram",
+      "typeVersion": 1.2,
+      "position": [
+        624,
+        112
+      ],
+      "id": "444421b6-e007-4d3f-a207-e00d026d348e",
+      "name": "Answer Unknown",
+      "webhookId": "YOUR_WEBHOOK_ID",
+      "credentials": {
+        "telegramApi": {
+          "id": "YOUR_CREDENTIAL_ID",
+          "name": "Telegram account"
+        }
+      }
+    }
+  ],
+  "pinData": {},
+  "connections": {
+    "Telegram Callback Webhook": {
+      "main": [
+        [
+          {
+            "node": "Parse Callback Data",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Parse Callback Data": {
+      "main": [
+        [
+          {
+            "node": "Route by Action",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Route by Action": {
+      "main": [
+        [
+          {
+            "node": "Answer Join",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Answer Skip",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Answer Unknown",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "active": true,
+  "settings": {
+    "executionOrder": "v1",
+    "binaryMode": "separate",
+    "timeSavedMode": "fixed",
+    "errorWorkflow": "YOUR_ERROR_WORKFLOW_ID",
+    "callerPolicy": "workflowsFromSameOwner",
+    "availableInMCP": false
+  },
+  "meta": {},
+  "tags": []
+}

--- a/workflows/telegram-callback-handler.json
+++ b/workflows/telegram-callback-handler.json
@@ -101,7 +101,7 @@
     {
       "parameters": {
         "resource": "callback",
-        "queryId": "=={{ $json.callback_query_id }}",
+        "queryId": "={{ $json.callback_query_id }}",
         "additionalFields": {
           "text": "✅ Joining…"
         }
@@ -125,7 +125,7 @@
     {
       "parameters": {
         "resource": "callback",
-        "queryId": "=={{ $json.callback_query_id }}",
+        "queryId": "={{ $json.callback_query_id }}",
         "additionalFields": {
           "text": "❌ Skipping…"
         }
@@ -149,7 +149,7 @@
     {
       "parameters": {
         "resource": "callback",
-        "queryId": "=={{ $json.callback_query_id }}",
+        "queryId": "={{ $json.callback_query_id }}",
         "additionalFields": {
           "text": "⚠️ Unknown action"
         }

--- a/workflows/telegram-callback-handler.json
+++ b/workflows/telegram-callback-handler.json
@@ -44,7 +44,7 @@
                 },
                 "conditions": [
                   {
-                    "leftValue": "=={{ $json.action }}",
+                    "leftValue": "={{ $json.action }}",
                     "rightValue": "join",
                     "operator": {
                       "type": "string",
@@ -69,7 +69,7 @@
                 "conditions": [
                   {
                     "id": "6603ba66-31b6-4186-a9cd-50c70c15b3dd",
-                    "leftValue": "= ={{ $json.action }}",
+                    "leftValue": "={{ $json.action }}",
                     "rightValue": "skip",
                     "operator": {
                       "type": "string",


### PR DESCRIPTION
## Summary

- Closes the Telegram callback loop end-to-end: the part-A sidecar (commit `1f9eca3`) registers the ngrok URL with Telegram on every `make up`; this PR adds the part-B n8n workflow that listens on `/webhook/telegram-callback` and routes each `callback_query` through a Switch on `action` (`join` / `skip` / fallback) into a per-branch `answerCallbackQuery` that dismisses the spinner.
- Foundation of epic #45: both the future accept branch (#28) and skip branch (#46) will graft their downstream logic onto the Switch outputs without touching the router.
- Scope strict (router stub only). Does NOT yet write to `state/watchlist.json`, dispatch to any downstream workflow, mark email read, or edit the original message — those are all explicitly owned by #46 / #28 / #27.

## Checklist

- [x] JSON files are valid (`make validate`)
- [x] n8n workflow imports successfully (already published as v1.1.0 with global Error Handler wired)
- [x] Docker compose starts without errors (`make up` — sidecar + workflow both healthy)
- [x] No secrets or credentials committed (sanitized via canonical jq filter; `credentials.*.id`, `webhookId`, `settings.errorWorkflow` placeholdered)
- [x] End-to-end smoke test: 3× simulated `callback_query` POST through the public ngrok URL (`action=join`, `action=skip`, `action=foo`) all return HTTP 200, Switch routes to the expected branch, `answerCallbackQuery` is invoked
- [x] `state/watchlist.json` untouched after the test calls (scope-stub guarantee)

Closes #31