### PR TITLE
chore(docker): widen healthcheck wget timeout from 3s to 7s

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -16,12 +16,17 @@ services:
       - ../rules:/data/rules:ro
       - ../state:/data/state
       - ./resolv.conf:/etc/resolv.conf:ro
+    # --timeout=7 (raised from 3s on 2026-04-28 per #59) absorbs short
+    # network latency spikes on the outbound 1.1.1.1 probe so a normal
+    # TLS 1.3 handshake on a marginal connection does not get marked
+    # unhealthy. The Retries: 3 budget is unchanged, so a real outage
+    # still triggers autoheal within ~3 minutes.
     healthcheck:
       test:
         - CMD-SHELL
         - >-
-          wget -q --spider --timeout=3 http://localhost:5678/healthz &&
-          wget -q --spider --timeout=3 https://1.1.1.1/
+          wget -q --spider --timeout=7 http://localhost:5678/healthz &&
+          wget -q --spider --timeout=7 https://1.1.1.1/
       interval: 60s
       timeout: 10s
       start_period: 60s


### PR DESCRIPTION
## Summary

- Raises the n8n container healthcheck `wget --timeout=3` to `--timeout=7` on both probes (`http://localhost:5678/healthz` and `https://1.1.1.1/`) to absorb the TLS-handshake latency variance that triggered 15 autoheal restart cycles between 2026-04-27 18:04 and 2026-04-28 00:14 (host RTT averaging 50ms with peaks at 66ms; 3s budget too tight for that envelope).
- Detection budget unchanged — `Retries: 3` still triggers autoheal within ~3 minutes for a real outage.
- Added an inline `# --timeout=7 ...` comment so the rationale survives the next investigation.

## Checklist

- [x] JSON files are valid (`make validate`)
- [x] n8n workflow imports successfully (no workflow change)
- [x] Docker compose starts without errors (`make up` + `--force-recreate n8n` — both clean)
- [x] No secrets or credentials committed (single docker-compose tweak)
- [x] Container reaches `healthy` post-recreate within `start_period: 60s`; first two probes ExitCode 0
- [x] Manual `wget --timeout=7 https://1.1.1.1/` from inside the container completes in 1.19s (well under new budget)

Closes #59